### PR TITLE
Encoder handles arbitrary unicode characters up to 4 bytes

### DIFF
--- a/crystalfontz/character/constants.py
+++ b/crystalfontz/character/constants.py
@@ -1,8 +1,6 @@
 # Characters that take more than one code point in unicode. These need to be
 # manually added to the character ROM.
-super_minus: str = "\u207b"
-super_one: str = "\u00B9"
-inverse: str = f"{super_minus}{super_one}"
+inverse: str = "\u207b\u00b9"
 x_bar: str = "x̄"
 
 # Characters which only require one code point, but are difficult to type

--- a/crystalfontz/device.py
+++ b/crystalfontz/device.py
@@ -72,7 +72,7 @@ CFA533_CHARACTER_ROM = (
 """  # noqa: W291, W293
     )
     .set_special_character_range(0, 7)
-    .set_encoding(inverse, 244 + 9)
+    .set_encoding(inverse, 224 + 9)
     .set_encoding(x_bar, 240 + 8)
 )
 

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,6 +1,6 @@
 import pytest
 
-from crystalfontz.character import SMILEY_FACE
+from crystalfontz.character import inverse, SMILEY_FACE, x_bar
 from crystalfontz.device import CFA533, CFA533_CHARACTER_ROM
 
 # Manually encoded characters
@@ -22,7 +22,11 @@ def test_encode_table(decoded, encoded) -> None:
 
 @pytest.mark.parametrize(
     "input,expected",
-    [("Hello world!", bytes([H, e, l, l, o, _, w, o, r, l, d, exclamation]))],
+    [
+        ("Hello world!", bytes([H, e, l, l, o, _, w, o, r, l, d, exclamation])),
+        (inverse, bytes([224 + 9])),
+        (x_bar, bytes([240 + 8])),
+    ],
 )
 def test_encode(input, expected) -> None:
     assert CFA533_CHARACTER_ROM.encode(input) == expected


### PR DESCRIPTION
I solved #13 by checking for encodings at 4 characters and coming down until the options were exhausted - backtracking, I guess. It's not the most efficient for single-byte encodings, but I'm not sure a trie would be much better.

Closes #13