### PR TITLE
closed method and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ yyyy/mm/dd Version 2.0.0
 - Watchdog CLI argument allows "disable" and "disabled" values
 - Configure device model, hardware revision and firmware revison in CLI
 - Do not show stack trace on connection errors in CLI
-- Add `client.closed()`
-- Handle errors by surfacing them either in the command calls or through `client.closed()`
+- Add `client.closed` future
+- Handle errors by surfacing them either in the command calls or through `client.closed`
+- Add `client` async contextmanager that awaits `client.closed`
 
 2025/01/04 Version 1.0.0
 ------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ yyyy/mm/dd Version 2.0.0
 - Configure device model, hardware revision and firmware revison in CLI
 - Do not show stack trace on connection errors in CLI
 - Add `client.closed()`
+- Handle errors by surfacing them either in the command calls or through `client.closed()`
 
 2025/01/04 Version 1.0.0
 ------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ yyyy/mm/dd Version 2.0.0
 - Watchdog CLI argument allows "disable" and "disabled" values
 - Configure device model, hardware revision and firmware revison in CLI
 - Do not show stack trace on connection errors in CLI
+- Add `client.closed()`
 
 2025/01/04 Version 1.0.0
 ------------------------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ async def main():
         report_handler=LoggingReportHandler()
     )
 
-    await client.closed
+    await client.closed()
 
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ async def main():
         report_handler=LoggingReportHandler()
     )
 
-    # Keep the coroutine open indefinitely
-    await asyncio.get_running_loop().create_future()
+    await client.closed
 
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ async def main():
         baud_rate=SLOW_BAUD_RATE
     ) as client:
         await client.send_data(0, 0, "Hello world!")
+        client.close()
 
 asyncio.run(main())
 ```

--- a/README.md
+++ b/README.md
@@ -9,18 +9,16 @@ Here's a basic example:
 ```py
 import asyncio
 
-from crystalfontz import create_connection, SLOW_BAUD_RATE
+from crystalfontz import client, SLOW_BAUD_RATE
 
 
 async def main():
-    client = await create_connection(
+    async with client(
         "/dev/ttyUSB0",
         model="CFA533",
         baud_rate=SLOW_BAUD_RATE
-    )
-
-    await client.send_data(0, 0, "Hello world!")
-
+    ) as client:
+        await client.send_data(0, 0, "Hello world!")
 
 asyncio.run(main())
 ```
@@ -39,14 +37,13 @@ import asyncio
 from crystalfontz import create_connection, LoggingReportHandler, SLOW_BAUD_RATE
 
 async def main():
-    client = await create_connection(
+    async with client(
         "/dev/ttyUSB0",
         model="CFA533",
-        baud_rate=SLOW_BAUD_RATE,
-        report_handler=LoggingReportHandler()
-    )
-
-    await client.closed()
+        report_handler=LoggingReportHandler(),
+        baud_rate=SLOW_BAUD_RATE
+    ) as client:
+        pass
 
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ from crystalfontz import client, SLOW_BAUD_RATE
 
 
 async def main():
+    # Will close the client on exit
     async with client(
         "/dev/ttyUSB0",
         model="CFA533",
         baud_rate=SLOW_BAUD_RATE
     ) as client:
         await client.send_data(0, 0, "Hello world!")
-        client.close()
 
 asyncio.run(main())
 ```
@@ -38,13 +38,15 @@ import asyncio
 from crystalfontz import create_connection, LoggingReportHandler, SLOW_BAUD_RATE
 
 async def main():
-    async with client(
+    client = await create_connection(
         "/dev/ttyUSB0",
         model="CFA533",
         report_handler=LoggingReportHandler(),
         baud_rate=SLOW_BAUD_RATE
-    ) as client:
-        pass
+    )
+
+    # Client will close if there's an error
+    await client.closed
 
 
 asyncio.run(main())

--- a/crystalfontz/__init__.py
+++ b/crystalfontz/__init__.py
@@ -2,7 +2,7 @@ from typing import List
 
 from crystalfontz.atx import AtxPowerSwitchFunction, AtxPowerSwitchFunctionalitySettings
 from crystalfontz.baud import BaudRate, FAST_BAUD_RATE, SLOW_BAUD_RATE
-from crystalfontz.client import Client, create_connection
+from crystalfontz.client import client, Client, create_connection
 from crystalfontz.command import Command
 from crystalfontz.cursor import CursorStyle
 from crystalfontz.device import Device, DeviceStatus
@@ -81,6 +81,7 @@ __all__: List[str] = [
     "BaudRateSet",
     "BootStateStored",
     "ClearedScreen",
+    "client",
     "Client",
     "Command",
     "CommandSentToLcdController",

--- a/crystalfontz/cli.py
+++ b/crystalfontz/cli.py
@@ -27,7 +27,7 @@ from serial.serialutil import SerialException
 
 from crystalfontz.atx import AtxPowerSwitchFunction, AtxPowerSwitchFunctionalitySettings
 from crystalfontz.baud import BaudRate, FAST_BAUD_RATE, SLOW_BAUD_RATE
-from crystalfontz.client import Client, create_connection
+from crystalfontz.client import client, Client
 from crystalfontz.config import Config, GLOBAL_FILE
 from crystalfontz.cursor import CursorStyle
 from crystalfontz.keys import (
@@ -161,7 +161,7 @@ WrappedAsyncCommand = Callable[..., None]
 AsyncCommandDecorator = Callable[[AsyncCommand], WrappedAsyncCommand]
 
 
-def client(
+def pass_client(
     run_forever: bool = False,
     report_handler_cls: Type[ReportHandler] = NoopReportHandler,
 ) -> AsyncCommandDecorator:
@@ -177,27 +177,23 @@ def client(
 
             async def main() -> None:
                 try:
-                    client: Client = await create_connection(
+                    async with client(
                         port,
                         model=model,
                         hardware_rev=hardware_rev,
                         firmware_rev=firmware_rev,
                         report_handler=report_handler_cls(),
                         baud_rate=baud_rate,
-                    )
+                    ) as c:
+                        await fn(c, *args, **kwargs)
+                        if not run_forever:
+                            c.close()
                 except SerialException as exc:
                     click.echo(exc)
                     sys.exit(1)
-                await fn(client, *args, **kwargs)
 
             try:
-                if run_forever:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                    loop.create_task(main())
-                    loop.run_forever()
-                else:
-                    asyncio.run(main())
+                asyncio.run(main())
             except KeyboardInterrupt:
                 pass
 
@@ -207,7 +203,7 @@ def client(
 
 
 @main.command(help="Listen for keypress and temperature reports")
-@client(run_forever=True, report_handler_cls=JsonReportHandler)
+@pass_client(run_forever=True, report_handler_cls=JsonReportHandler)
 async def listen(client: Client) -> None:
     """
     Listen for key and temperature reports. To configure which reports to
@@ -219,14 +215,14 @@ async def listen(client: Client) -> None:
 
 @main.command(help="0 (0x00): Ping command")
 @click.argument("payload")
-@client()
+@pass_client()
 async def ping(client: Client, payload: str) -> None:
     pong = await client.ping(payload.encode("utf8"))
     click.echo(pong.response)
 
 
 @main.command(help="1 (0x01): Get Hardware & Firmware Version")
-@client()
+@pass_client()
 async def versions(client: Client) -> None:
     versions = await client.versions()
     click.echo(f"{versions.model}: {versions.hardware_rev}, {versions.firmware_rev}")
@@ -239,14 +235,14 @@ def flash() -> None:
 
 @flash.command(name="write", help="2 (0x02): Write User Flash Area")
 @click.argument("data")
-@client()
+@pass_client()
 async def write_user_flash_area(client: Client, data: str) -> None:
     # Click doesn't have a good way of receiving bytes as arguments.
     raise NotImplementedError("crystalfontz user-flash-area write")
 
 
 @flash.command(name="read", help="3 (0x03): Read User Flash Area")
-@client()
+@pass_client()
 async def read_user_flash_area(client: Client) -> None:
     flash = await client.read_user_flash_area()
     # TODO: Does this print as raw bytes?
@@ -254,7 +250,7 @@ async def read_user_flash_area(client: Client) -> None:
 
 
 @main.command(help="4 (0x04): Store Current State as Boot State")
-@client()
+@pass_client()
 async def store(client: Client) -> None:
     await client.store_boot_state()
 
@@ -265,25 +261,25 @@ def power() -> None:
 
 
 @power.command(help="Reboot the Crystalfontx LCD")
-@client()
+@pass_client()
 async def reboot_lcd(client: Client) -> None:
     await client.reboot_lcd()
 
 
 @power.command(help="Reset the host, assuming ATX control is configured")
-@client()
+@pass_client()
 async def reset_host(client: Client) -> None:
     await client.reset_host()
 
 
 @power.command(help="Turn the host's power off, assuming ATX control is configured")
-@client()
+@pass_client()
 async def shutdown_host(client: Client) -> None:
     await client.shutdown_host()
 
 
 @main.command(help="6 (0x06): Clear LCD Screen")
-@client()
+@pass_client()
 async def clear(client: Client) -> None:
     await client.clear_screen()
 
@@ -295,14 +291,14 @@ def line() -> None:
 
 @line.command(name="1", help="7 (0x07): Set LCD Contents, Line 1")
 @click.argument("line")
-@client()
+@pass_client()
 async def set_line_1(client: Client, line: str) -> None:
     await client.set_line_1(line)
 
 
 @line.command(name="2", help="8 (0x08): Set LCD Contents, Line 2")
 @click.argument("line")
-@client()
+@pass_client()
 async def set_line_2(client: Client, line: str) -> None:
     await client.set_line_2(line)
 
@@ -330,7 +326,7 @@ def lcd() -> None:
 
 @lcd.command(name="poke", help="10 (0x0A): Read 8 Bytes of LCD Memory")
 @click.argument("address", type=BYTE)
-@client()
+@pass_client()
 async def read_lcd_memory(client: Client, address: int) -> None:
     memory = await client.read_lcd_memory(address)
     click.echo(bytes(memory.address) + b":" + memory.data)
@@ -344,21 +340,21 @@ def cursor() -> None:
 @cursor.command(name="position", help="11 (0x0B): Set LCD Cursor Position")
 @click.argument("row", type=BYTE)
 @click.argument("column", type=BYTE)
-@client()
+@pass_client()
 async def set_cursor_position(client: Client, row: int, column: int) -> None:
     await client.set_cursor_position(row, column)
 
 
 @cursor.command(name="style", help="12 (0x0C): Set LCD Cursor Style")
 @click.argument("style", type=click.Choice([e.name for e in CursorStyle]))
-@client()
+@pass_client()
 async def set_cursor_style(client: Client, style: str) -> None:
     await client.set_cursor_style(CursorStyle[style])
 
 
 @main.command(help="13 (0x0D): Set LCD Contrast")
 @click.argument("contrast", type=float)
-@client()
+@pass_client()
 async def contrast(client: Client, contrast: float) -> None:
     await client.set_contrast(contrast)
 
@@ -366,7 +362,7 @@ async def contrast(client: Client, contrast: float) -> None:
 @main.command(help="14 (0x0E): Set LCD & Keypad Backlight")
 @click.argument("brightness", type=float)
 @click.option("--keypad", type=float)
-@client()
+@pass_client()
 async def backlight(client: Client, brightness: float, keypad: Optional[float]) -> None:
     await client.set_backlight(brightness, keypad)
 
@@ -378,7 +374,7 @@ def dow() -> None:
 
 @dow.command(name="info", help="18 (0x12): Read DOW Device Information")
 @click.argument("index", type=BYTE)
-@client()
+@pass_client()
 async def read_dow_device_information(client: Client, index: int) -> None:
     info = await client.read_dow_device_information(index)
     click.echo(bytes(info.index) + b":" + info.rom_id)
@@ -391,7 +387,7 @@ def temperature() -> None:
 
 @temperature.command(name="reporting", help="19 (0x13): Set Up Temperature Reporting")
 @click.argument("enabled", nargs=-1)
-@client()
+@pass_client()
 async def setup_temperature_reporting(client: Client, enabled: Tuple[int]) -> None:
     await client.setup_temperature_reporting(enabled)
 
@@ -414,7 +410,7 @@ def dow_transaction() -> None:
 @click.option("--column", "-c", type=BYTE, required=True)
 @click.option("--row", "-r", type=BYTE, required=True)
 @click.option("--units", "-U", type=click.Choice([e.name for e in TemperatureUnit]))
-@client()
+@pass_client()
 async def setup_live_temperature_display(
     client: Client,
     slot: int,
@@ -439,7 +435,7 @@ async def setup_live_temperature_display(
 @lcd.command(name="send", help="22 (0x16): Send Command Directly to the LCD Controller")
 @click.argument("location", type=click.Choice([e.name for e in LcdRegister]))
 @click.argument("data", type=BYTE)
-@client()
+@pass_client()
 async def send_command_to_lcd_controler(
     client: Client, location: str, data: int
 ) -> None:
@@ -468,7 +464,7 @@ KEYPRESSES: Dict[str, KeyPress] = dict(
 @click.option(
     "--when-released", multiple=True, type=click.Choice(list(KEYPRESSES.keys()))
 )
-@client()
+@pass_client()
 async def configure_key_reporting(
     client: Client, when_pressed: List[str], when_released: List[str]
 ) -> None:
@@ -479,7 +475,7 @@ async def configure_key_reporting(
 
 
 @keypad.command(name="poll", help="24 (0x18): Read Keypad, Polled Mode")
-@client()
+@pass_client()
 async def poll_keypad(client: Client) -> None:
     polled = await client.poll_keypad()
     click.echo(json.dumps(polled.states.as_dict(), indent=2))
@@ -491,7 +487,7 @@ async def poll_keypad(client: Client) -> None:
 )
 @click.option("--auto-polarity/--no-auto-polarity", type=bool, default=False)
 @click.option("--power-pulse-length-seconds", type=float)
-@client()
+@pass_client()
 async def atx(
     client: Client,
     function: List[str],
@@ -509,13 +505,13 @@ async def atx(
 
 @main.command(help="29 (0x1D): Enable/Disable and Reset the Watchdog")
 @click.argument("timeout_seconds", type=WATCHDOG_SETTING)
-@client()
+@pass_client()
 async def watchdog(client: Client, timeout_seconds: int) -> None:
     await client.configure_watchdog(timeout_seconds)
 
 
 @main.command(help="30 (0x1E): Read Reporting & Status")
-@client()
+@pass_client()
 async def status(client: Client) -> None:
     status = await client.read_status()
 
@@ -559,7 +555,7 @@ async def status(client: Client) -> None:
 @click.argument("row", type=int)
 @click.argument("column", type=int)
 @click.argument("data")
-@client()
+@pass_client()
 async def send(client: Client, row: int, column: int, data: str) -> None:
     await client.send_data(row, column, data)
 
@@ -600,7 +596,7 @@ def effects() -> None:
 @click.argument("text")
 @click.option("--pause", type=float)
 @click.option("--tick", type=float)
-@client()
+@pass_client()
 async def marquee(
     client: Client, row: int, text: str, pause: Optional[float], tick: Optional[float]
 ) -> None:
@@ -612,7 +608,7 @@ async def marquee(
 @effects.command(help="Display a screensaver-like effect")
 @click.argument("text")
 @click.option("--tick", type=float)
-@client()
+@pass_client()
 async def screensaver(client: Client, text: str, tick: Optional[float]) -> None:
     s = client.screensaver(text, tick=tick)
 

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -30,7 +30,7 @@ from serial import EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 from serial_asyncio import create_serial_connection, SerialTransport
 
 from crystalfontz.atx import AtxPowerSwitchFunctionalitySettings
-from crystalfontz.baud import BaudRate
+from crystalfontz.baud import BaudRate, SLOW_BAUD_RATE
 from crystalfontz.character import SpecialCharacter
 from crystalfontz.command import (
     ClearScreen,
@@ -571,7 +571,7 @@ async def create_connection(
     device: Optional[Device] = None,
     report_handler: Optional[ReportHandler] = None,
     loop: Optional[asyncio.AbstractEventLoop] = None,
-    baud_rate: BaudRate = 19200,
+    baud_rate: BaudRate = SLOW_BAUD_RATE,
 ) -> Client:
     _loop = loop if loop else asyncio.get_running_loop()
 
@@ -607,7 +607,7 @@ async def client(
     device: Optional[Device] = None,
     report_handler: Optional[ReportHandler] = None,
     loop: Optional[asyncio.AbstractEventLoop] = None,
-    baud_rate: BaudRate = 19200,
+    baud_rate: BaudRate = SLOW_BAUD_RATE,
 ) -> AsyncGenerator[Client, None]:
     client = await create_connection(
         port,

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -1,9 +1,11 @@
 import asyncio
 from collections import defaultdict
+from contextlib import asynccontextmanager
 import logging
 import traceback
 from typing import (
     Any,
+    AsyncGenerator,
     Callable,
     cast,
     Coroutine,
@@ -611,3 +613,30 @@ async def create_connection(
     await client._connection_made
 
     return client
+
+
+@asynccontextmanager
+async def client(
+    port: str,
+    model: str = "CFA533",
+    hardware_rev: Optional[str] = None,
+    firmware_rev: Optional[str] = None,
+    device: Optional[Device] = None,
+    report_handler: Optional[ReportHandler] = None,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    baud_rate: BaudRate = 19200,
+) -> AsyncGenerator[Client, None]:
+    client = await create_connection(
+        port,
+        model=model,
+        hardware_rev=hardware_rev,
+        firmware_rev=firmware_rev,
+        device=device,
+        report_handler=report_handler,
+        loop=loop,
+        baud_rate=baud_rate,
+    )
+
+    yield client
+
+    await client.closed()

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -273,6 +273,7 @@ class Client(asyncio.Protocol):
             self._close(exc)
 
     def _packet_received(self: Self, packet: Packet) -> None:
+        logging.debug(f"Packet received: {packet}")
         try:
             res = Response.from_packet(packet)
             raw_res = (

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -196,14 +196,13 @@ class Client(asyncio.Protocol):
         else:
             self._close()
 
-    async def close(self: Self) -> None:
+    def close(self: Self) -> None:
         """
         Close the connection.
         """
         if self._transport:
             self._transport.close()
         self._close()
-        return await self.closed()
 
     async def closed(self: Self) -> None:
         """

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -627,4 +627,5 @@ async def client(
 
     yield client
 
+    client.close()
     await client.closed

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -283,8 +283,8 @@ class Client(asyncio.Protocol):
             # We know the intended response type, so send it to any subscribers
             self._emit(exc.response_cls, (exc, None))
         except DeviceError as exc:
-            if exc.expected in RESPONSE_CLASSES:
-                self._emit(RESPONSE_CLASSES[exc.expected], (exc, None))
+            if exc.expected_response in RESPONSE_CLASSES:
+                self._emit(RESPONSE_CLASSES[exc.expected_response], (exc, None))
             else:
                 self._close(exc)
         except Exception as exc:

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -264,11 +264,12 @@ class Client(asyncio.Protocol):
 
         tasks_done.add_done_callback(on_tasks_done)
 
-        if not self._closed or self._closed.done():
-            # No way to resolve a future.
+        if not self._closed:
+            warnings.warn("Client closed without awaiting client.closed()")
             if exc:
                 raise exc
-            return
+        elif self._closed.done() and exc:
+            raise exc
 
     def data_received(self: Self, data: bytes) -> None:
         try:

--- a/crystalfontz/effects.py
+++ b/crystalfontz/effects.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import asyncio
 import random
 import time
-from typing import Any, Iterable, Optional, Protocol, Set, Type, TypeVar
+from typing import Any, Iterable, Optional, Protocol, Set, Tuple, Type, TypeVar
 
 try:
     from typing import Self
@@ -51,6 +51,7 @@ from crystalfontz.response import (
 from crystalfontz.temperature import TemperatureDisplayItem
 
 R = TypeVar("R", bound=Response)
+Result = Tuple[Exception, None] | Tuple[None, R]
 
 
 class ClientProtocol(Protocol):
@@ -60,9 +61,9 @@ class ClientProtocol(Protocol):
 
     device: Device
 
-    def subscribe(self: Self, cls: Type[R]) -> asyncio.Queue[R]: ...
+    def subscribe(self: Self, cls: Type[R]) -> asyncio.Queue[Result[R]]: ...
 
-    def unsubscribe(self: Self, cls: Type[R], q: asyncio.Queue[R]) -> None: ...
+    def unsubscribe(self: Self, cls: Type[R], q: asyncio.Queue[Result[R]]) -> None: ...
 
     async def ping(self: Self, payload: bytes) -> Pong: ...
 

--- a/crystalfontz/error.py
+++ b/crystalfontz/error.py
@@ -43,9 +43,9 @@ class ResponseDecodeError(DecodeError):
     An error while decoding a response.
     """
 
-    def __init__(self: Self, code: int, message: str) -> None:
+    def __init__(self: Self, response_cls: Type[Any], message: str) -> None:
         super().__init__(message)
-        self.code: int = code
+        self.response_cls: Type[Any] = response_cls
 
 
 class EncodeError(CrystalfontzError):

--- a/crystalfontz/error.py
+++ b/crystalfontz/error.py
@@ -95,7 +95,7 @@ class DeviceError(CrystalfontzError):
         self.command = code & 0o77
         # The expected response code, so we can match this error with the
         # expected success response
-        self.expected = self.command + 0x40
+        self.expected_response = self.command + 0x40
         self.payload = payload
         message = f"Error executing command 0x{self.command:02X}"
 

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -333,9 +333,7 @@ class TemperatureReport(Response):
         assert_len(4, data)
 
         self.idx: int = data[0]
-        # TODO: This should be data[1:3], but it's triggering an error case
-        # I want to fix graceful handling for first
-        value = struct.unpack(">H", data[1:2])[0]
+        value = struct.unpack(">H", data[1:3])[0]
         dow_crc_status = data[3]
 
         if dow_crc_status == 0:

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -333,6 +333,8 @@ class TemperatureReport(Response):
         assert_len(4, data)
 
         self.idx: int = data[0]
+        # TODO: This should be data[1:3], but it's triggering an error case
+        # I want to fix graceful handling for first
         value = struct.unpack(">H", data[1:2])[0]
         dow_crc_status = data[3]
 

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -36,10 +36,11 @@ class Response(ABC):
     def from_packet(cls: Type[Self], packet: Packet) -> "Response":
         code, data = packet
         if code in RESPONSE_CLASSES:
+            res_cls = RESPONSE_CLASSES[code]
             try:
-                return RESPONSE_CLASSES[code](data)
+                return res_cls(data)
             except Exception as exc:
-                raise ResponseDecodeError(code, str(exc)) from exc
+                raise ResponseDecodeError(res_cls, str(exc)) from exc
 
         if DeviceError.is_error_code(code):
             raise DeviceError(packet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ include = ["crystalfontz", "tests"]
 addopts = "--verbose -s"
 testpaths = [ "tests" ]
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.setuptools]
 packages = [ "crystalfontz" ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "flake8",
     "flake8-black",
     "pytest",
+    "pytest-asyncio",
     "black",
     "isort",
     "jupyter-console",
@@ -56,16 +57,17 @@ dev = [
 # Specified for the benefit of compiling requirements-dev.txt
 [project.optional-dependencies]
 dev = [
-  "flake8",
-  "flake8-black",
-  "pytest",
-  "black",
-  "isort",
-  "jupyter-console",
-  "mkdocs",
-  "mkdocs-bootstrap386",
-  "mkdocstrings[python]",
-  "validate-pyproject[all]",
+    "flake8",
+    "flake8-black",
+    "pytest",
+    "pytest-asyncio",
+    "black",
+    "isort",
+    "jupyter-console",
+    "mkdocs",
+    "mkdocs-bootstrap386",
+    "mkdocstrings[python]",
+    "validate-pyproject[all]",
 ]
 
 [tool.uv]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,10 +57,13 @@ async def client(
 async def test_report_handler(
     client: Client, report_handler: ReportHandler, packet: Packet, method: str
 ) -> None:
+    f = client.closed()
     client._packet_received(packet)
 
     await asyncio.sleep(0.1)
 
-    await client.close()
+    client.close()
+
+    await f
 
     getattr(report_handler, method).assert_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,64 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import pytest_asyncio
+from serial_asyncio import SerialTransport
+
+from crystalfontz.client import Client
+from crystalfontz.device import CFA533, Device
+from crystalfontz.packet import Packet
+from crystalfontz.report import ReportHandler
+
+
+@pytest.fixture
+def device() -> Device:
+    return CFA533()
+
+
+@pytest.fixture
+def report_handler() -> ReportHandler:
+    handler = Mock(name="MockReportHandler()")
+
+    handler.on_key_activity = AsyncMock(name="MockReportHandler().on_key_activity")
+    handler.on_temperature = AsyncMock(name="MockReportHandler().on_temperature")
+
+    return handler
+
+
+@pytest.fixture
+def transport() -> SerialTransport:
+    return Mock(name="SerialTransport()")
+
+
+@pytest_asyncio.fixture(scope="function")
+async def client(
+    device: Device, report_handler: ReportHandler, transport: SerialTransport
+) -> Client:
+    client = Client(
+        device=device, report_handler=report_handler, loop=asyncio.get_running_loop()
+    )
+    client._is_serial_transport = Mock(return_value=True)
+    client.connection_made(transport)
+    return client
+
+
+@pytest.mark.parametrize(
+    "packet,method",
+    [
+        ((0x80, b"\x01"), "on_key_activity"),
+        # TODO: This case is failing.
+        # ((0x82, b"\x01\x01\x00\xff"), "on_temperature"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_report_handler(
+    client: Client, report_handler: ReportHandler, packet: Packet, method: str
+) -> None:
+    client._packet_received(packet)
+
+    await asyncio.sleep(0.1)
+
+    await client.close()
+
+    getattr(report_handler, method).assert_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,7 +67,7 @@ async def test_close_exc(client: Client) -> None:
 @pytest.mark.asyncio
 async def test_ping_success(client: Client) -> None:
     q = client.subscribe(Pong)
-    client._packet_received((0x00, b"ping!"))
+    client._packet_received((0x40, b"ping!"))
     async with asyncio.timeout(0.2):
         exc, res = await q.get()
     client.unsubscribe(Pong, q)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,6 +118,18 @@ async def test_device_error(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_device_error_no_sub(client: Client) -> None:
+    client._packet_received((0b11000000, b"ping!"))
+
+    await asyncio.sleep(0.1)
+
+    with pytest.raises(DeviceError):
+        client.close()
+
+        await client.closed
+
+
+@pytest.mark.asyncio
 async def test_response_decode_error(client: Client) -> None:
     q = client.subscribe(BrokenResponse)
     client._packet_received((0x64, b"oops!"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,9 +7,8 @@ import pytest_asyncio
 from serial_asyncio import SerialTransport
 
 from crystalfontz.client import Client
-from crystalfontz.command import Ping
 from crystalfontz.device import CFA533, Device
-from crystalfontz.error import DeviceError, ResponseDecodeError
+from crystalfontz.error import DeviceError, ResponseDecodeError, UnknownResponseError
 from crystalfontz.packet import Packet
 from crystalfontz.report import ReportHandler
 from crystalfontz.response import KeyActivityReport, Pong
@@ -79,6 +78,14 @@ async def test_ping_success(client: Client) -> None:
     client.close()
 
     await client.closed
+
+
+@pytest.mark.asyncio
+async def test_unknown_response(client: Client) -> None:
+    client._packet_received((0x00, b"wat"))
+
+    with pytest.raises(UnknownResponseError):
+        await client.closed
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,7 +42,7 @@ def transport() -> SerialTransport:
     return Mock(name="SerialTransport()")
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest_asyncio.fixture
 async def client(
     device: Device, report_handler: ReportHandler, transport: SerialTransport
 ) -> Client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -124,8 +124,6 @@ async def test_device_error_no_sub(client: Client) -> None:
     await asyncio.sleep(0.1)
 
     with pytest.raises(DeviceError):
-        client.close()
-
         await client.closed
 
 
@@ -146,6 +144,16 @@ async def test_response_decode_error(client: Client) -> None:
     client.close()
 
     await client.closed
+
+
+@pytest.mark.asyncio
+async def test_response_decode_error_no_sub(client: Client) -> None:
+    client._packet_received((0x64, b"oops!"))
+
+    await asyncio.sleep(0.1)
+
+    with pytest.raises(ResponseDecodeError):
+        await client.closed
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,13 +57,12 @@ async def client(
 async def test_report_handler(
     client: Client, report_handler: ReportHandler, packet: Packet, method: str
 ) -> None:
-    f = client.closed()
     client._packet_received(packet)
 
     await asyncio.sleep(0.1)
 
     client.close()
 
-    await f
+    await client.closed
 
     getattr(report_handler, method).assert_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -9,6 +10,8 @@ from crystalfontz.client import Client
 from crystalfontz.device import CFA533, Device
 from crystalfontz.packet import Packet
 from crystalfontz.report import ReportHandler
+
+logging.basicConfig(level="DEBUG")
 
 
 @pytest.fixture
@@ -47,8 +50,7 @@ async def client(
     "packet,method",
     [
         ((0x80, b"\x01"), "on_key_activity"),
-        # TODO: This case is failing.
-        # ((0x82, b"\x01\x01\x00\xff"), "on_temperature"),
+        ((0x82, b"\x01\x01\x00\xff"), "on_temperature"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,6 +128,21 @@ async def test_device_error_no_sub(client: Client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_arbitrary_error_no_sub(client: Client, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "crystalfontz.response.Response.from_packet",
+        Mock(name="Response.from_packet()", side_effect=Exception("oops!")),
+    )
+
+    client._packet_received((0x40, b"ping!"))
+
+    await asyncio.sleep(0.1)
+
+    with pytest.raises(Exception):
+        await client.closed
+
+
+@pytest.mark.asyncio
 async def test_response_decode_error(client: Client) -> None:
     q = client.subscribe(BrokenResponse)
     client._packet_received((0x64, b"oops!"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,7 +109,7 @@ async def test_device_error(client: Client) -> None:
 
     assert isinstance(exc, DeviceError)
     assert exc.command == 0x00
-    assert exc.expected == 0x40
+    assert exc.expected_response == 0x40
     assert res is None
 
     client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -223,6 +223,7 @@ dev = [
     { name = "mkdocs-bootstrap386" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "validate-pyproject", extra = ["all"] },
 ]
 
@@ -237,6 +238,7 @@ dev = [
     { name = "mkdocs-bootstrap386" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "validate-pyproject", extra = ["all"] },
 ]
 
@@ -256,6 +258,7 @@ requires-dist = [
     { name = "pyserial" },
     { name = "pyserial-asyncio" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pyyaml" },
     { name = "validate-pyproject", extras = ["all"], marker = "extra == 'dev'" },
 ]
@@ -271,6 +274,7 @@ dev = [
     { name = "mkdocs-bootstrap386" },
     { name = "mkdocstrings", extras = ["python"] },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "validate-pyproject", extras = ["all"] },
 ]
 
@@ -898,6 +902,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/04/0477a4bdd176ad678d148c075f43620b3f7a060ff61c7da48500b1fa8a75/pytest_asyncio-0.25.1.tar.gz", hash = "sha256:79be8a72384b0c917677e00daa711e07db15259f4d23203c59012bcd989d4aee", size = 53760 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/fb/efc7226b384befd98d0e00d8c4390ad57f33c8fde00094b85c5e07897def/pytest_asyncio-0.25.1-py3-none-any.whl", hash = "sha256:c84878849ec63ff2ca509423616e071ef9cd8cc93c053aa33b5b8fb70a990671", size = 19357 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a `client.closed()` method as in #14, which returns a Future that will get resolved when the client is closed. This is useful for keeping asyncio running in cases where you don't want to immediately exit after a command.

It also adds the error handling as discussed in #33. The two issues were heavily coupled, so I solved them in one go.

I feel good about this API, but this is all so complicated that I need to craft some unit tests before this can reasonably be merged. I'll also want to move away from `run_forever` when `await client.closed()` will do.

- [x] Write unit tests
- [x] Use `client.closed` in CLI
- [x] Revisit error property names
- [x] Ticket for emitting issues on queues with active get

Closes #14 #33
See #7 #8