### PR TITLE
Overhaul CLI API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,27 @@ yyyy/mm/dd Version x.y.z
 - Support Python 3.11
 - Add PyPI classifiers
 - Support arbitrary multi-byte encodings in character ROM
-- rename `crystalfontz read-lcd-memory` and `crystalfonts send-command-to-lcd-controller` to `crystalfontz lcd poke` and `crystalfontz lcd send` respectively
-
+- Refactor CLI command names
+  - `read-lcd-memory` -> `lcd poke`
+  - `send-command-to-lcd-controller` -> `lcd send`
+  - `user-flash-area` -> `flash`
+  - `store-boot-state` -> `store`
+  - `clear-screen` -> `clear`
+  - `set-line-1` -> `line 1`
+  - `set-line-2` -> `line 2`
+  - `special-character` -> `character`
+  - `cursor set-position` -> `cursor position`
+  - `cursor set-style` -> `cursor style`
+  - `set-contrast` -> `constrast`
+  - `set-backlight` -> `backlight`
+  - `dow read-device-information` -> `dow info`
+  - `temperature setup-reporting` -> `temperature reporting`
+  - `temperature setup-live-display` -> `temperature display`
+  - `keypad configure-reporting` -> `keypad reporting`
+  - `set-atx-power-switch-functionality` -> `atx`
+  - `configure-watchdog` -> `watchdog`
+  - `read-status` -> `status`
+  - `set-baud-rate` -> `baud`
 
 2025/01/04 Version 1.0.0
 ------------------------


### PR DESCRIPTION
Output now looks like:

```
crystalfontz --help
Usage: crystalfontz [OPTIONS] COMMAND [ARGS]...

  Control your Crystalfontz LCD

Options:
  --global / --no-global          Load the global config file at
                                  /etc/crystalfontz.yaml
  --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Set the log level
  --port TEXT                     The serial port the Crystalfontz LCD is
                                  connected to
  --baud [19200|115200]           The baud rate to use when connecting to the
                                  Crystalfontz LCD
  --help                          Show this message and exit.

Commands:
  atx          28 (0x1C): Set ATX Power Switch Functionality
  backlight    14 (0x0E): Set LCD & Keypad Backlight
  baud         33 (0x21): Set Baud Rate
  character    Interact with special characters
  clear        6 (0x06): Clear LCD Screen
  contrast     13 (0x0D): Set LCD Contrast
  cursor       Interact with the LCD cursor
  dow          DOW (Dallas One-Wire) capabilities
  effects      Run various effects, such as marquees
  flash        Interact with the User Flash Area
  gpio         Interact with GPIO pins
  keypad       Interact with the keypad
  lcd          Interact directly with the LCD controller
  line         Set LCD contents for a line
  listen       Listen for keypress and temperature reports
  ping         0 (0x00): Ping command
  power        5 (0x05): Reboot LCD, Reset Host, or Power Off Host
  send         31 (0x1F): Send Data to LCD
  status       30 (0x1E): Read Reporting & Status
  store        4 (0x04): Store Current State as Boot State
  temperature  Temperature reporting and live display
  versions     1 (0x01): Get Hardware & Firmware Version
  watchdog     29 (0x1D): Enable/Disable and Reset the Watchdog
```

```
crystalfontz cursor --help
Usage: crystalfontz cursor [OPTIONS] COMMAND [ARGS]...

  Interact with the LCD cursor

Options:
  --help  Show this message and exit.

Commands:
  position  11 (0x0B): Set LCD Cursor Position
  style     12 (0x0C): Set LCD Cursor Style
```

```
crystalfontz dow --help
Usage: crystalfontz dow [OPTIONS] COMMAND [ARGS]...

  DOW (Dallas One-Wire) capabilities

Options:
  --help  Show this message and exit.

Commands:
  info         18 (0x12): Read DOW Device Information
  transaction  20 (0x14): Arbitrary DOW Transaction
```

```
crystalfontz keypad --help
Usage: crystalfontz keypad [OPTIONS] COMMAND [ARGS]...

  Interact with the keypad

Options:
  --help  Show this message and exit.

Commands:
  poll       24 (0x18): Read Keypad, Polled Mode
  reporting  23 (0x17): Configure Key Reporting
```

```
crystalfontz line --help
Usage: crystalfontz line [OPTIONS] COMMAND [ARGS]...

  Set LCD contents for a line

Options:
  --help  Show this message and exit.

Commands:
  1  7 (0x07): Set LCD Contents, Line 1
  2  8 (0x08): Set LCD Contents, Line 2
```

```
crystalfontz temperature --help
Usage: crystalfontz temperature [OPTIONS] COMMAND [ARGS]...

  Temperature reporting and live display

Options:
  --help  Show this message and exit.

Commands:
  display    21 (0x15): Set Up Live Temperature Display
  reporting  19 (0x13): Set Up Temperature Reporting
```

Closes #23