### PR TITLE
Output Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support for `crystalfontz dow transaction`
 - `client.dow_transaction`'s `data_to_write` argument defaults to empty bytes
 - Support for `crystalfontz gpio write` and `crystalfontz gpio read`
+- CLI supports `--output text` and `--output json`
 
 ## 2025/01/09 Version 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Options:
   --hardware-rev TEXT             The hardware revision of the device
   --firmware-rev TEXT             The firmware revision of the device
   --detect / --no-detect          When set, detect device version
+  --output [text|json]            Output either human-friendly text or JSON
   --timeout FLOAT                 How long to wait for a response from the
                                   device before timing out
   --retry-times INTEGER           How many times to retry a command if a
@@ -150,6 +151,10 @@ Commands:
 ### Byte Parameters
 
 Some CLI parameters encode raw bytes. In these cases, the inputs support [the same escape sequences as Python's byte strings](https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences). This includes hex numbers (`\xff`) and octal numbers (`\o333`). Note that unicode characters are parsed as utf-8.
+
+### Output Format
+
+This CLI supports two output formats: `text` and `json`. The former will output a human-readable format, and the latter will output JSON. When generating JSON output, bytes are encoded in base64.
 
 ### Open Issues
 

--- a/crystalfontz/atx.py
+++ b/crystalfontz/atx.py
@@ -56,6 +56,8 @@ class AtxPowerSwitchFunctionalitySettings:
             if settings[0] & function.value:
                 functions.add(function)
         auto_polarity: bool = bool(settings[0] & AUTO_POLARITY)
+        reset_invert: bool = bool(settings[0] & RESET_INVERT)
+        power_invert: bool = bool(settings[0] & POWER_INVERT)
         power_pulse_length_seconds: Optional[float] = (
             settings[1] / 32 if len(settings) > 1 else None
         )
@@ -63,6 +65,8 @@ class AtxPowerSwitchFunctionalitySettings:
         return cls(
             functions=functions,
             auto_polarity=auto_polarity,
+            reset_invert=reset_invert,
+            power_invert=power_invert,
             power_pulse_length_seconds=power_pulse_length_seconds,
         )
 
@@ -88,3 +92,11 @@ class AtxPowerSwitchFunctionalitySettings:
             packed += min(pulse_length, 255).to_bytes(length=1)
 
         return packed
+
+    def __repr__(self: Self) -> str:
+        repr_ = "Functions enabled: {', '.join([e.name for e in self.functions])}\n"
+        repr_ += "Auto-Polarity Enabled: {'yes' if self.auto_polarity else 'no'}\n"
+        repr_ += "Reset Inverted: {'yes' if self.reset_invert else 'no'}\n"
+        repr_ += "Power Inverted: {'yes' if self.power_invert else 'no'}\n"
+        repr_ += "Power Pulse Length (seconds): {self.power_pulse_length_seconds}"
+        return repr_

--- a/crystalfontz/atx.py
+++ b/crystalfontz/atx.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Optional, Set, Type
+from typing import Any, Dict, Optional, Set, Type
 
 try:
     from typing import Self
@@ -93,10 +93,19 @@ class AtxPowerSwitchFunctionalitySettings:
 
         return packed
 
+    def as_dict(self: Self) -> Dict[str, Any]:
+        as_ = asdict(self)
+
+        as_["functions"] = [fn.value for fn in self.functions]
+
+        print(as_)
+
+        return as_
+
     def __repr__(self: Self) -> str:
-        repr_ = "Functions enabled: {', '.join([e.name for e in self.functions])}\n"
-        repr_ += "Auto-Polarity Enabled: {'yes' if self.auto_polarity else 'no'}\n"
-        repr_ += "Reset Inverted: {'yes' if self.reset_invert else 'no'}\n"
-        repr_ += "Power Inverted: {'yes' if self.power_invert else 'no'}\n"
-        repr_ += "Power Pulse Length (seconds): {self.power_pulse_length_seconds}"
+        repr_ = f"Functions enabled: {', '.join([e.name for e in self.functions])}\n"
+        repr_ += f"Auto-Polarity Enabled: {'yes' if self.auto_polarity else 'no'}\n"
+        repr_ += f"Reset Inverted: {'yes' if self.reset_invert else 'no'}\n"
+        repr_ += f"Power Inverted: {'yes' if self.power_invert else 'no'}\n"
+        repr_ += f"Power Pulse Length (seconds): {self.power_pulse_length_seconds}"
         return repr_

--- a/crystalfontz/cli.py
+++ b/crystalfontz/cli.py
@@ -260,20 +260,22 @@ FUNCTION = Function()
 DRIVE_MODE = DriveMode()
 
 
+def as_json(obj: Any) -> Any:
+    if hasattr(obj, "as_dict"):
+        return obj.as_dict()
+    elif is_dataclass(obj.__class__):
+        return asdict(obj)
+    else:
+        return obj
+
+
 class CliWriter:
     mode: OutputMode = "text"
 
     def echo(self: Self, obj: Any, *args, **kwargs) -> None:
         if self.mode == "json":
-            if hasattr(obj, "as_dict"):
-                jsobj: Any = obj.as_dict()
-            elif is_dataclass(obj.__class__):
-                jsobj: Any = asdict(obj)
-            else:
-                jsobj: Any = obj
-
             try:
-                click.echo(json.dumps(jsobj, indent=2), *args, **kwargs)
+                click.echo(json.dumps(as_json(obj), indent=2), *args, **kwargs)
             except Exception as exc:
                 logger.debug(exc)
                 click.echo(json.dumps(repr(obj)), *args, **kwargs)

--- a/crystalfontz/cli.py
+++ b/crystalfontz/cli.py
@@ -33,7 +33,7 @@ from crystalfontz.config import Config, GLOBAL_FILE
 from crystalfontz.cursor import CursorStyle
 from crystalfontz.effects import Effect
 from crystalfontz.error import CrystalfontzError
-from crystalfontz.format import OutputMode
+from crystalfontz.format import format_json_bytes, OutputMode
 from crystalfontz.gpio import GpioDriveMode, GpioFunction, GpioSettings
 from crystalfontz.keys import (
     KeyPress,
@@ -265,6 +265,8 @@ def as_json(obj: Any) -> Any:
         return obj.as_dict()
     elif is_dataclass(obj.__class__):
         return asdict(obj)
+    elif isinstance(obj, bytes):
+        return format_json_bytes(obj)
     else:
         return obj
 
@@ -280,7 +282,11 @@ class CliWriter:
                 logger.debug(exc)
                 click.echo(json.dumps(repr(obj)), *args, **kwargs)
         else:
-            click.echo(obj if isinstance(obj, bytes) else repr(obj), *args, **kwargs)
+            click.echo(
+                obj if isinstance(obj, bytes) else repr(obj),
+                *args,
+                **kwargs,
+            )
 
 
 REPORT_HANDLER = CliReportHandler()

--- a/crystalfontz/cli.py
+++ b/crystalfontz/cli.py
@@ -337,7 +337,12 @@ echo = WRITER.echo
     default=False,
     help="When set, detect device version",
 )
-@click.option("--output", type=click.Choice(["text", "json"]), default="text")
+@click.option(
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output either human-friendly text or JSON",
+)
 @click.option(
     "--timeout",
     type=float,

--- a/crystalfontz/client.py
+++ b/crystalfontz/client.py
@@ -221,7 +221,7 @@ class Client(asyncio.Protocol):
     ) -> None:
 
         self.device: Device = device
-        self._report_handler: ReportHandler = report_handler
+        self.report_handler: ReportHandler = report_handler
         self._default_timeout: float = timeout
         self._default_retry_times: int = retry_times
 
@@ -264,14 +264,14 @@ class Client(asyncio.Protocol):
             self._handle_report(
                 "key_activity",
                 self._key_activity_queue,
-                self._report_handler.on_key_activity,
+                self.report_handler.on_key_activity,
             )
         )
         self._temperature_task: asyncio.Task[None] = self.loop.create_task(
             self._handle_report(
                 "temperature",
                 self._temperature_queue,
-                self._report_handler.on_temperature,
+                self.report_handler.on_temperature,
             )
         )
 

--- a/crystalfontz/device.py
+++ b/crystalfontz/device.py
@@ -150,7 +150,7 @@ class CFA533Status:
         )
 
     def __repr__(self: Self) -> str:
-        repr_ = "CFA533 status:\n"
+        repr_ = "CFA533 Status:\n"
         repr_ += ("-" * (len(repr_) - 1)) + "\n"
 
         enabled = ", ".join(

--- a/crystalfontz/device.py
+++ b/crystalfontz/device.py
@@ -1,8 +1,8 @@
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import logging
 import textwrap
-from typing import Any, Optional, Set
+from typing import Any, Dict, Optional, Set
 
 try:
     from typing import Self
@@ -135,9 +135,23 @@ class CFA533Status:
     cfa633_contrast: float
     lcd_brightness: float
 
+    def as_dict(self: Self) -> Dict[str, Any]:
+        atx = (self.atx_power_switch_functionality_settings.as_dict(),)
+        return dict(
+            temperature_sensors_enabled=list(self.temperature_sensors_enabled),
+            key_states=asdict(self.key_states),
+            atx_power_switch_functionality_settings=atx,
+            watchdog_counter=self.watchdog_counter,
+            contrast=self.contrast,
+            keypad_brightness=self.keypad_brightness,
+            atx_sense_on_floppy=self.atx_sense_on_floppy,
+            cfa633_contrast=self.cfa633_contrast,
+            lcd_brightness=self.lcd_brightness,
+        )
+
     def __repr__(self: Self) -> str:
         repr_ = "CFA533 status:\n"
-        repr_ += ("-" * (len(repr_) - 1)) + "\n\n"
+        repr_ += ("-" * (len(repr_) - 1)) + "\n"
 
         enabled = ", ".join(
             [f"{e}" for e in sorted(list(self.temperature_sensors_enabled))]
@@ -153,12 +167,12 @@ class CFA533Status:
             + "\n"
         )
 
-        repr_ += "Watchdog Counter: {self.watchdog_counter}\n"
-        repr_ += "Contrast: {self.contrast}\n"
-        repr_ += "Contrast (CFA633 Compatible): {self.cfa633_contrast}\n"
+        repr_ += f"Watchdog Counter: {self.watchdog_counter}\n"
+        repr_ += f"Contrast: {self.contrast}\n"
+        repr_ += f"Contrast (CFA633 Compatible): {self.cfa633_contrast}\n"
         repr_ += "Backlight:\n"
-        repr_ += "  Keypad Brightness: {self.keypad_brightness}\n"
-        repr_ += "  LCD Brightness: {self.lcd_brightness}"
+        repr_ += f"  Keypad Brightness: {self.keypad_brightness}\n"
+        repr_ += f"  LCD Brightness: {self.lcd_brightness}"
 
         return repr_
 

--- a/crystalfontz/device.py
+++ b/crystalfontz/device.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from dataclasses import dataclass
 import logging
+import textwrap
 from typing import Any, Optional, Set
 
 try:
@@ -133,6 +134,33 @@ class CFA533Status:
     atx_sense_on_floppy: bool
     cfa633_contrast: float
     lcd_brightness: float
+
+    def __repr__(self: Self) -> str:
+        repr_ = "CFA533 status:\n"
+        repr_ += ("-" * (len(repr_) - 1)) + "\n\n"
+
+        enabled = ", ".join(
+            [f"{e}" for e in sorted(list(self.temperature_sensors_enabled))]
+        )
+        repr_ += "Temperature sensors enabled: " + enabled + "\n"
+
+        repr_ += "Key states:\n"
+        repr_ += textwrap.indent(repr(self.key_states), "  ") + "\n"
+
+        repr_ += "ATX Power Switch Functionality Settings:\n"
+        repr_ += (
+            textwrap.indent(repr(self.atx_power_switch_functionality_settings), "  ")
+            + "\n"
+        )
+
+        repr_ += "Watchdog Counter: {self.watchdog_counter}\n"
+        repr_ += "Contrast: {self.contrast}\n"
+        repr_ += "Contrast (CFA633 Compatible): {self.cfa633_contrast}\n"
+        repr_ += "Backlight:\n"
+        repr_ += "  Keypad Brightness: {self.keypad_brightness}\n"
+        repr_ += "  LCD Brightness: {self.lcd_brightness}"
+
+        return repr_
 
 
 class CFA533(Device):

--- a/crystalfontz/format.py
+++ b/crystalfontz/format.py
@@ -1,0 +1,3 @@
+from typing import Literal
+
+OutputMode = Literal["text"] | Literal["json"]

--- a/crystalfontz/format.py
+++ b/crystalfontz/format.py
@@ -1,3 +1,7 @@
 from typing import Literal
 
 OutputMode = Literal["text"] | Literal["json"]
+
+
+def format_bytes(buffer: bytes) -> str:
+    return str(buffer)[2:-1]

--- a/crystalfontz/format.py
+++ b/crystalfontz/format.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Literal
 
 OutputMode = Literal["text"] | Literal["json"]
@@ -5,3 +6,7 @@ OutputMode = Literal["text"] | Literal["json"]
 
 def format_bytes(buffer: bytes) -> str:
     return str(buffer)[2:-1]
+
+
+def format_json_bytes(buffer: bytes) -> str:
+    return base64.b64encode(buffer).decode("utf-8")

--- a/crystalfontz/gpio.py
+++ b/crystalfontz/gpio.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, NoReturn, Optional, Tuple, Type
+from typing import Any, Dict, NoReturn, Optional, Tuple, Type
 
 try:
     from typing import Self
@@ -167,8 +167,21 @@ class GpioSettings:
         mode = data & 0b0111
         return cls(function=function, mode=mode)
 
+    def as_dict(self: Self) -> Dict[str, Any]:
+        up, down = GpioDriveMode.from_byte(self.mode)
+        return dict(
+            function=self.function.value,
+            mode=self.mode,
+            up=up.name if up is not None else None,
+            down=down.name if down is not None else None,
+        )
+
     def __repr__(self: Self) -> str:
+        up, down = GpioDriveMode.from_byte(self.mode)
         repr_ = f"Function: {self.function.value}\n"
-        repr_ += "Drive Mode: {self.up.value}, {self.down.value}"
+        repr_ += (
+            f"Drive Mode: {up.name if up is not None else '<none>'}, "
+            f"{down.name if down is not None else '<none>'}"
+        )
 
         return repr_

--- a/crystalfontz/gpio.py
+++ b/crystalfontz/gpio.py
@@ -166,3 +166,9 @@ class GpioSettings:
         function = GpioFunction.USED if data & 0b1000 else GpioFunction.UNUSED
         mode = data & 0b0111
         return cls(function=function, mode=mode)
+
+    def __repr__(self: Self) -> str:
+        repr_ = f"Function: {self.function.value}\n"
+        repr_ += "Drive Mode: {self.up.value}, {self.down.value}"
+
+        return repr_

--- a/crystalfontz/keys.py
+++ b/crystalfontz/keys.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Dict, List, Type
+from typing import Any, List, Type
 
 try:
     from typing import Self
@@ -94,13 +94,10 @@ class KeyStates:
             ),
         )
 
-    def as_dict(self: Self) -> Dict[str, Dict[str, bool]]:
-        return {key: state for key, state in asdict(self).items()}
-
     def __repr__(self: Self) -> str:
         repr_ = ""
-        for name, state in self.as_dict().items():
-            st = ", ".join([f"{n}: {'yes' if s else 'no'}" for n, s in state.items()])
+        for name, state in asdict(self).items():
+            st = ", ".join([f"{n}={'yes' if s else 'no'}" for n, s in state.items()])
             repr_ += f"{name}: {st}\n"
         return repr_[0:-1]
 

--- a/crystalfontz/keys.py
+++ b/crystalfontz/keys.py
@@ -97,6 +97,13 @@ class KeyStates:
     def as_dict(self: Self) -> Dict[str, Dict[str, bool]]:
         return {key: state for key, state in asdict(self).items()}
 
+    def __repr__(self: Self) -> str:
+        repr_ = ""
+        for name, state in self.as_dict().items():
+            st = ", ".join([f"{n}: {'yes' if s else 'no'}" for n, s in state.items()])
+            repr_ += f"{name}: {st}\n"
+        return repr_[0:-1]
+
 
 class KeyActivity(Enum):
     """

--- a/crystalfontz/report.py
+++ b/crystalfontz/report.py
@@ -1,13 +1,14 @@
 from abc import ABC, abstractmethod
 import json
 import logging
-from typing import Any
+from typing import Any, Optional
 
 try:
     from typing import Self
 except ImportError:
     Self = Any
 
+from crystalfontz.format import OutputMode
 from crystalfontz.response import KeyActivityReport, TemperatureReport
 
 
@@ -60,21 +61,17 @@ class LoggingReportHandler(ReportHandler):
         self.logger.info(report)
 
 
-class JsonReportHandler(ReportHandler):
+class CliReportHandler(ReportHandler):
+    mode: Optional[OutputMode] = None
+
     async def on_key_activity(self: Self, report: KeyActivityReport) -> None:
-        print(
-            json.dumps(
-                dict(type=report.__class__.__name__, activity=report.activity.name)
-            )
-        )
+        if self.mode == "json":
+            print(json.dumps(report.as_dict()))
+        elif self.mode == "text":
+            print(repr(report))
 
     async def on_temperature(self: Self, report: TemperatureReport) -> None:
-        print(
-            json.dumps(
-                dict(
-                    type=report.__class__.__name__,
-                    celsius=report.celsius,
-                    fahrenheit=report.fahrenheit,
-                )
-            )
-        )
+        if self.mode == "json":
+            print(json.dumps(report.as_dict()))
+        elif self.mode == "text":
+            print(repr(report))

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -382,6 +382,12 @@ class KeyActivityReport(Response):
     def __str__(self: Self) -> str:
         return f"KeyActivityReport({self.activity.name})"
 
+    def __repr__(self: Self) -> str:
+        return f"{self.__class__.__name__}\t{self.activity.name}"
+
+    def as_dict(self: Self) -> Dict[str, Any]:
+        return dict(type=self.__class__.__name__, activity=self.activity.name)
+
 
 @code(0x82)
 class TemperatureReport(Response):
@@ -411,4 +417,14 @@ class TemperatureReport(Response):
         return (
             f"TemperatureReport({self.index}, celsius={self.celsius}, "
             f"fahrenheit={self.fahrenheit})"
+        )
+
+    def __repr__(self: Self) -> str:
+        return f"{self.__class__.__name__}\t{self.celsius}\t{self.fahrenheit}"
+
+    def as_dict(self: Self) -> Dict[str, Any]:
+        return dict(
+            type=self.__class__.__name__,
+            celsius=self.celsius,
+            fahrenheit=self.fahrenheit,
         )

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -297,13 +297,10 @@ class DowTransactionResult(Response):
         return dict(index=self.index, data=format_json_bytes(self.data), crc=self.crc)
 
     def __repr__(self: Self) -> str:
-        return "\n".join(
-            [
-                f"index: 0x{self.index:02X}",
-                f"data: {format_bytes(self.data)}",
-                f"crc: 0x{self.crc:02X}",
-            ]
-        )
+        repr_ = f"Transaction Result for Device {self.index}:\n"
+        repr_ += f"  Data: {format_bytes(self.data)}\n"
+        repr_ += f"  CRC: 0x{self.crc:02X}"
+        return repr_
 
 
 @code(0x55)
@@ -342,7 +339,7 @@ class KeypadPolled(Response):
         return dict(states=asdict(self.states))
 
     def __repr__(self: Self) -> str:
-        repr_ = "Keypad states:\n"
+        repr_ = "Keypad States:\n"
         repr_ += textwrap.indent(repr(self.states), "  ")
 
         return repr_

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import struct
+import textwrap
 from typing import Any, Callable, cast, Dict, Type, TypeVar
 
 try:
@@ -128,6 +129,9 @@ class Versions(Response):
             f"firmware_rev={self.firmware_rev})"
         )
 
+    def __repr__(self: Self) -> str:
+        return f"{self.model}: {self.hardware_rev}, {self.firmware_rev}"
+
 
 @code(0x42)
 class UserFlashAreaWritten(Ack):
@@ -201,6 +205,9 @@ class LcdMemory(Response):
     def __str__(self: Self) -> str:
         return f"LcdMemory(0x{self.address:02X}={self.data})"
 
+    def __repr__(self: Self) -> str:
+        return f"{self.address}: {self.data}"
+
 
 @code(0x4B)
 class CursorPositionSet(Ack):
@@ -239,7 +246,10 @@ class DowDeviceInformation(Response):
         self.rom_id: bytes = data[1:]
 
     def __str__(self: Self) -> str:
-        return f"DownDeviceInformation({self.index}={self.rom_id})"
+        return f"DowDeviceInformation({self.index}={self.rom_id})"
+
+    def __repr__(self: Self) -> str:
+        return f"{self.index}: {self.rom_id}"
 
 
 @code(0x53)
@@ -264,6 +274,11 @@ class DowTransactionResult(Response):
 
     def __str__(self: Self) -> str:
         return f"DowTransactionResult({self.index}, data={self.data}, crc={self.crc})"
+
+    def __repr__(self: Self) -> str:
+        return "\n".join(
+            [f"index: {self.index}", f"data: {self.data}", f"crc: {self.crc}"]
+        )
 
 
 @code(0x55)
@@ -297,6 +312,12 @@ class KeypadPolled(Response):
 
     def __str__(self: Self) -> str:
         return f"KeypadPolled(states={self.states})"
+
+    def __repr__(self: Self) -> str:
+        repr_ = "Keypad states:\n"
+        repr_ += textwrap.indent(repr(self.states), "  ")
+
+        return repr_
 
 
 @code(0x5C)
@@ -363,6 +384,13 @@ class GpioRead(Response):
             f"GpioRead({self.index}, state={self.state}, "
             f"requested_level={self.requested_level}, settings={self.settings}"
         )
+
+    def __repr__(self: Self) -> str:
+        repr_ = "GPIO pin # {self.index}:\n"
+        repr_ += "  Requested Level: {self.requested_level}\n"
+        repr_ += "  Settings:\n"
+        repr_ += textwrap.indent(repr(self.settings), "    ")
+        return repr_
 
 
 @code(0x80)

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import base64
 import struct
 import textwrap
 from typing import Any, Callable, cast, Dict, Type, TypeVar
@@ -14,6 +15,7 @@ from crystalfontz.error import (
     ResponseDecodeError,
     UnknownResponseError,
 )
+from crystalfontz.format import format_bytes
 from crystalfontz.gpio import GpioSettings, GpioState
 from crystalfontz.keys import KeyActivity, KeyStates
 from crystalfontz.packet import Packet
@@ -129,6 +131,13 @@ class Versions(Response):
             f"firmware_rev={self.firmware_rev})"
         )
 
+    def as_dict(self: Self) -> Dict[str, Any]:
+        return dict(
+            model=self.model,
+            hardware_rev=self.hardware_rev,
+            firmware_rev=self.firmware_rev,
+        )
+
     def __repr__(self: Self) -> str:
         return f"{self.model}: {self.hardware_rev}, {self.firmware_rev}"
 
@@ -205,8 +214,13 @@ class LcdMemory(Response):
     def __str__(self: Self) -> str:
         return f"LcdMemory(0x{self.address:02X}={self.data})"
 
+    def as_dict(self: Self) -> Dict[str, Any]:
+        return dict(
+            address=self.address, data=base64.b64encode(self.data).decode("utf-8")
+        )
+
     def __repr__(self: Self) -> str:
-        return f"{self.address}: {self.data}"
+        return f"0x{self.address:02X}: {format_bytes(self.data)}"
 
 
 @code(0x4B)

--- a/justfile
+++ b/justfile
@@ -79,6 +79,11 @@ test:
   uv run pytest ./tests
   @just _clean-test
 
+# Update snapshots
+snap:
+  uv run pytest --snapshot-update ./tests
+  @just _clean-test
+
 # Run simple integration test suite
 integration:
   uv run bash ./tests/integration.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "mkdocs",
     "mkdocs-include-markdown-plugin",
     "mkdocstrings[python]",
+    "syrupy",
     "validate-pyproject[all]",
 ]
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -26,4 +26,5 @@ jupyter-console
 mkdocs
 mkdocs-include-markdown-plugin
 mkdocstrings[python]
+syrupy
 validate-pyproject[all]

--- a/requirements_dev.txt.in
+++ b/requirements_dev.txt.in
@@ -8,4 +8,5 @@ jupyter-console
 mkdocs
 mkdocs-include-markdown-plugin
 mkdocstrings[python]
+syrupy
 validate-pyproject[all]

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -31,14 +31,14 @@
 # ---
 # name: test_repr[obj3]
   '''
-  index: 0xFF
-  data: \x01\x02\x03\x04\x05\x06\x07
-  crc: 0xFF
+  Transaction Result for Device 255:
+    Data: \x01\x02\x03\x04\x05\x06\x07
+    CRC: 0xFF
   '''
 # ---
 # name: test_repr[obj4]
   '''
-  Keypad states:
+  Keypad States:
     up: pressed=yes, pressed_since=yes, released_since=yes
     enter: pressed=no, pressed_since=no, released_since=no
     exit: pressed=no, pressed_since=no, released_since=no
@@ -49,7 +49,7 @@
 # ---
 # name: test_repr[obj5]
   '''
-  CFA533 status:
+  CFA533 Status:
   --------------
   Temperature sensors enabled: 1, 2
   Key states:

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -1,7 +1,13 @@
 # serializer version: 1
+# name: test_json[obj0]
+  '{"model": "CFA533", "hardware_rev": "h1.4", "firmware_rev": "u1v2"}'
+# ---
+# name: test_json[obj1]
+  '{"address": 255, "data": "AAECAwQFBgc="}'
+# ---
 # name: test_repr[obj0]
   'CFA533: h1.4, u1v2'
 # ---
 # name: test_repr[obj1]
-  "255: \\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07"
+  '0xFF: \\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07'
 # ---

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -1,4 +1,7 @@
 # serializer version: 1
+# name: test_json[\x01]
+  '"AQ=="'
+# ---
 # name: test_json[obj0]
   '{"model": "CFA533", "hardware_rev": "h1.4", "firmware_rev": "u1v2"}'
 # ---
@@ -19,6 +22,9 @@
 # ---
 # name: test_json[obj6]
   '{"index": 255, "state": {"state": true, "falling": true, "rising": true}, "requested_level": 17, "settings": {"function": 8, "mode": 5, "up": "SLOW_STRONG", "down": "SLOW_STRONG"}}'
+# ---
+# name: test_repr[\x01]
+  "b'\\x01'"
 # ---
 # name: test_repr[obj0]
   'CFA533: h1.4, u1v2'

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -5,9 +5,80 @@
 # name: test_json[obj1]
   '{"address": 255, "data": "AAECAwQFBgc="}'
 # ---
+# name: test_json[obj2]
+  '{"index": 255, "rom_id": "AAECAwQFBgc="}'
+# ---
+# name: test_json[obj3]
+  '{"index": 255, "data": "AQIDBAUGBw==", "crc": 255}'
+# ---
+# name: test_json[obj4]
+  '{"states": {"up": {"pressed": true, "pressed_since": true, "released_since": true}, "enter": {"pressed": false, "pressed_since": false, "released_since": false}, "exit": {"pressed": false, "pressed_since": false, "released_since": false}, "left": {"pressed": false, "pressed_since": false, "released_since": false}, "right": {"pressed": false, "pressed_since": false, "released_since": false}, "down": {"pressed": false, "pressed_since": false, "released_since": false}}}'
+# ---
+# name: test_json[obj5]
+  '{"temperature_sensors_enabled": [1, 2], "key_states": {"up": {"pressed": false, "pressed_since": true, "released_since": true}, "enter": {"pressed": false, "pressed_since": true, "released_since": true}, "exit": {"pressed": false, "pressed_since": true, "released_since": true}, "left": {"pressed": false, "pressed_since": true, "released_since": true}, "right": {"pressed": false, "pressed_since": true, "released_since": true}, "down": {"pressed": false, "pressed_since": true, "released_since": true}}, "atx_power_switch_functionality_settings": [{"functions": [32], "auto_polarity": true, "reset_invert": false, "power_invert": false, "power_pulse_length_seconds": 1.0}], "watchdog_counter": 0, "contrast": 0.5, "keypad_brightness": 0.5, "atx_sense_on_floppy": false, "cfa633_contrast": 0.5, "lcd_brightness": 0.5}'
+# ---
+# name: test_json[obj6]
+  '{"index": 255, "state": {"state": true, "falling": true, "rising": true}, "requested_level": 17, "settings": {"function": 8, "mode": 5, "up": "SLOW_STRONG", "down": "SLOW_STRONG"}}'
+# ---
 # name: test_repr[obj0]
   'CFA533: h1.4, u1v2'
 # ---
 # name: test_repr[obj1]
   '0xFF: \\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07'
+# ---
+# name: test_repr[obj2]
+  '0xFF: \\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07'
+# ---
+# name: test_repr[obj3]
+  '''
+  index: 0xFF
+  data: \x01\x02\x03\x04\x05\x06\x07
+  crc: 0xFF
+  '''
+# ---
+# name: test_repr[obj4]
+  '''
+  Keypad states:
+    up: pressed=yes, pressed_since=yes, released_since=yes
+    enter: pressed=no, pressed_since=no, released_since=no
+    exit: pressed=no, pressed_since=no, released_since=no
+    left: pressed=no, pressed_since=no, released_since=no
+    right: pressed=no, pressed_since=no, released_since=no
+    down: pressed=no, pressed_since=no, released_since=no
+  '''
+# ---
+# name: test_repr[obj5]
+  '''
+  CFA533 status:
+  --------------
+  Temperature sensors enabled: 1, 2
+  Key states:
+    up: pressed=no, pressed_since=yes, released_since=yes
+    enter: pressed=no, pressed_since=yes, released_since=yes
+    exit: pressed=no, pressed_since=yes, released_since=yes
+    left: pressed=no, pressed_since=yes, released_since=yes
+    right: pressed=no, pressed_since=yes, released_since=yes
+    down: pressed=no, pressed_since=yes, released_since=yes
+  ATX Power Switch Functionality Settings:
+    Functions enabled: KEYPAD_RESET
+    Auto-Polarity Enabled: yes
+    Reset Inverted: no
+    Power Inverted: no
+    Power Pulse Length (seconds): 1.0
+  Watchdog Counter: 0
+  Contrast: 0.5
+  Contrast (CFA633 Compatible): 0.5
+  Backlight:
+    Keypad Brightness: 0.5
+    LCD Brightness: 0.5
+  '''
+# ---
+# name: test_repr[obj6]
+  '''
+  GPIO pin 255:
+    Requested Level: 17
+    Settings:
+      Function: 8
+      Drive Mode: SLOW_STRONG, SLOW_STRONG
+  '''
 # ---

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_repr[obj0]
+  'CFA533: h1.4, u1v2'
+# ---
+# name: test_repr[obj1]
+  "255: \\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07"
+# ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,18 @@ from typing import Any
 
 import pytest
 
+from crystalfontz.atx import AtxPowerSwitchFunction, AtxPowerSwitchFunctionalitySettings
 from crystalfontz.cli import as_json, parse_bytes
-
-# from crystalfontz.device import CFA533Status
-from crystalfontz.response import LcdMemory, Versions
+from crystalfontz.device import CFA533Status
+from crystalfontz.keys import KeyState, KeyStates, KP_UP
+from crystalfontz.response import (
+    DowDeviceInformation,
+    DowTransactionResult,
+    GpioRead,
+    KeypadPolled,
+    LcdMemory,
+    Versions,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,11 +39,34 @@ def test_parse_bytes(text, buffer) -> None:
 OBJECTS = [
     Versions(b"CFA533: h1.4, u1v2"),
     LcdMemory(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
-    # DowDeviceInformation(b""),
-    # DowTransactionResult(b""),
-    # KeypadPolled(b""),
-    # CFA533Status(...),
-    # GpioRead(b""),
+    DowDeviceInformation(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
+    DowTransactionResult(b"\xff\x01\x02\x03\x04\x05\x06\x07\xff"),
+    KeypadPolled(bytes([KP_UP, KP_UP, KP_UP])),
+    CFA533Status(
+        temperature_sensors_enabled={1, 2},
+        key_states=KeyStates(
+            up=KeyState(pressed=False, pressed_since=True, released_since=True),
+            enter=KeyState(pressed=False, pressed_since=True, released_since=True),
+            exit=KeyState(pressed=False, pressed_since=True, released_since=True),
+            left=KeyState(pressed=False, pressed_since=True, released_since=True),
+            right=KeyState(pressed=False, pressed_since=True, released_since=True),
+            down=KeyState(pressed=False, pressed_since=True, released_since=True),
+        ),
+        atx_power_switch_functionality_settings=AtxPowerSwitchFunctionalitySettings(
+            functions={AtxPowerSwitchFunction.KEYPAD_RESET},
+            auto_polarity=True,
+            reset_invert=False,
+            power_invert=False,
+            power_pulse_length_seconds=1.0,
+        ),
+        watchdog_counter=0,
+        contrast=0.5,
+        keypad_brightness=0.5,
+        atx_sense_on_floppy=False,
+        cfa633_contrast=0.5,
+        lcd_brightness=0.5,
+    ),
+    GpioRead(bytes([0xFF, 0b0111, 0x11, 0b1101])),
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,7 @@ OBJECTS = [
         lcd_brightness=0.5,
     ),
     GpioRead(bytes([0xFF, 0b0111, 0x11, 0b1101])),
+    b"\01",
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,12 @@
+import json
+from typing import Any
+
 import pytest
 
-from crystalfontz.cli import parse_bytes
+from crystalfontz.cli import as_json, parse_bytes
+
+# from crystalfontz.device import CFA533Status
+from crystalfontz.response import LcdMemory, Versions
 
 
 @pytest.mark.parametrize(
@@ -20,3 +26,24 @@ from crystalfontz.cli import parse_bytes
 @pytest.mark.filterwarnings("ignore:invalid escape sequence")
 def test_parse_bytes(text, buffer) -> None:
     assert parse_bytes(text) == buffer
+
+
+OBJECTS = [
+    Versions(b"CFA533: h1.4, u1v2"),
+    LcdMemory(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
+    # DowDeviceInformation(b""),
+    # DowTransactionResult(b""),
+    # KeypadPolled(b""),
+    # CFA533Status(...),
+    # GpioRead(b""),
+]
+
+
+@pytest.mark.parametrize("obj", OBJECTS)
+def test_repr(obj: Any, snapshot) -> None:
+    assert repr(obj) == snapshot
+
+
+@pytest.mark.parametrize("obj", OBJECTS)
+def test_json(obj: Any, snapshot) -> None:
+    assert json.dumps(as_json(obj)) == snapshot

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,7 @@ dev = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "syrupy" },
     { name = "validate-pyproject", extra = ["all"] },
 ]
 
@@ -258,6 +259,7 @@ dev = [
     { name = "mkdocstrings", extras = ["python"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "syrupy" },
     { name = "validate-pyproject", extras = ["all"] },
 ]
 
@@ -1055,6 +1057,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
+name = "syrupy"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/54/07f40c1e9355c0eb6909b83abd8ea2c523a1e05b8257a575bbaa42df28de/syrupy-4.8.0.tar.gz", hash = "sha256:648f0e9303aaa8387c8365d7314784c09a6bab0a407455c6a01d6a4f5c6a8ede", size = 49526 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl", hash = "sha256:544f4ec6306f4b1c460fdab48fd60b2c7fe54a6c0a8243aeea15f9ad9c638c3f", size = 49530 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR does a few related things:

1. The CLI accepts an `--output` flag, which may be set to "text" or "json"
2. `JsonReportHandler` has been replaced with `CliReportHandler`, which supports both json and text output modes
3. Text output modes have been delegated to `__repr__` methods in most cases

Tests are looking good! I just need to run the integration test suite, and experiment with output formats a little bit.

Note: `click.echo` purports to print bytes as bytes, so any concerns I had there should be assuaged.

Closes #29 