### PR TITLE
Configuration persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 ## yyyy/mm/dd Version x.y.z
 - Fedora package on COPR: <https://copr.fedorainfracloud.org/coprs/jfhbrook/joshiverse/package/python-crystalfontz/>
-- Rename `client.load_device` to `client.detect_device`
-- `--detect` flag to call `client.detect_device()`
-- `crystalfontz ping` may receive encoded bytes
-- Support for `crystalfontz flash write`
-- Support for `crystalfontz dow transaction`
-- `client.dow_transaction`'s `data_to_write` argument defaults to empty bytes
-- Support for `crystalfontz gpio write` and `crystalfontz gpio read`
-- CLI supports `--output text` and `--output json`
-- Export `Config` class used by CLI
+- Client API Changes:
+  - Rename `client.load_device` to `client.detect_device`
+  - `client.dow_transaction`'s `data_to_write` argument defaults to empty bytes
+  - New `client.test_connection` method
+  - New `client.detect_baud_rate` method
+- CLI Improvements and Features:
+  - `crystalfontz ping` may receive encoded bytes
+  - Support for `crystalfontz flash write`
+  - Support for `crystalfontz dow transaction`
+  - Support for `crystalfontz gpio write`
+  - Support for `crystalfontz gpio read`
+  - Support for `crystalfontz baud`
+  - Support for `--output text` and `--output json`
+  - New `crystalfontz config` command group
+  - Global config loaded by default when command called with sudo
+- Configuration Improvements and Features:
+  - Export `Config` class used by CLI
+  - Add `get`, `set` and `unset` methods to `Config` class
 
 ## 2025/01/09 Version 3.0.1
 

--- a/crystalfontz/baud.py
+++ b/crystalfontz/baud.py
@@ -1,6 +1,11 @@
-from typing import Literal
+from typing import Dict, Literal
 
 BaudRate = Literal[19200] | Literal[115200]
 
 SLOW_BAUD_RATE: BaudRate = 19200
 FAST_BAUD_RATE: BaudRate = 115200
+
+OTHER_BAUD_RATE: Dict[BaudRate, BaudRate] = {
+    SLOW_BAUD_RATE: FAST_BAUD_RATE,
+    FAST_BAUD_RATE: SLOW_BAUD_RATE,
+}

--- a/crystalfontz/cli.py
+++ b/crystalfontz/cli.py
@@ -451,7 +451,7 @@ def pass_client(
     "--log-level",
     envvar="CRYSTALFONTZ_LOG_LEVEL",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
-    default="WARNING",
+    default="INFO",
     help="Set the log level",
 )
 @click.option(

--- a/tests/__snapshots__/test_config.ambr
+++ b/tests/__snapshots__/test_config.ambr
@@ -1,0 +1,13 @@
+# serializer version: 1
+# name: test_repr
+  '''
+  baud_rate: 19200
+  firmware_rev: null
+  hardware_rev: null
+  model: CFA533
+  port: /dev/ttyUSB0
+  retry_times: 0
+  timeout: 0.25
+  
+  '''
+# ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+import pytest
+
+from crystalfontz.baud import FAST_BAUD_RATE
+from crystalfontz.config import Config
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "port",
+        "model",
+        "hardware_rev",
+        "firmware_rev",
+        "baud_rate",
+        "timeout",
+        "retry_times",
+    ],
+)
+def test_get(config: Config, name: str) -> None:
+    assert config.get(name) == getattr(config, name)
+
+
+def test_get_unknown(config: Config) -> None:
+    with pytest.raises(ValueError):
+        config.get("pony")
+
+
+@pytest.mark.parametrize(
+    "name,value,expected",
+    [
+        ("port", "/dev/ttyUSB1", "/dev/ttyUSB1"),
+        ("model", "some_model", "some_model"),
+        ("hardware_rev", "1.2.3", "1.2.3"),
+        ("firmware_rev", "1.2.3", "1.2.3"),
+        ("baud_rate", str(FAST_BAUD_RATE), FAST_BAUD_RATE),
+        ("timeout", "1.2", 1.2),
+        ("retry_times", "5", 5),
+    ],
+)
+def test_set(config: Config, name: str, value: str, expected: Any) -> None:
+    config.set(name, value)
+    assert config.get(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("baud_rate", "100"),
+        (
+            "retry_times",
+            "5.5",
+        ),
+    ],
+)
+def test_set_value_error(config: Config, name: str, value: str) -> None:
+    with pytest.raises(ValueError):
+        config.set(name, value)
+
+
+def test_set_unknown(config: Config) -> None:
+    with pytest.raises(ValueError):
+        config.set("pony", "pony")
+
+
+@pytest.mark.parametrize("name", ["hardware_rev", "firmware_rev"])
+def test_unset(config: Config, name: str) -> None:
+    config.unset(name)
+    assert config.get(name) is None
+
+
+@pytest.mark.parametrize("name", ["port", "model", "baud_rate"])
+def test_unset_required(config: Config, name: str) -> None:
+    with pytest.raises(ValueError):
+        config.unset(name)
+
+
+def test_repr(config: Config, snapshot) -> None:
+    assert repr(config) == snapshot


### PR DESCRIPTION
This PR does a few things:

- Exposes model, revisions and baud rate as properties on `Client`
- Adds `test_connection` and `detect_baud_rate` methods to the client
- Adds `crystalfontz config` command group that supports both CRUD and `crystalfontz config detect`
  - `crystalfontz config detect` uses `detect_baud_rate` and `detect_device` accordingly
  - Removes `--detect` flag, in favor of `crystalfontz config detect`
- CRUD methods for `Config`
- Adds new `crystalfontz baud` command with `--save` flag

All together, this closes #6.

This PR includes decent test coverage of the new `Config` features. I think the only reasonable way to test this is going to be with exploratory tests on my machine.

I did some basic testing with the new `config` commands, and that all seems great.

Note: #6 calls out use cases around special characters. I'm going to punt on that interface until I tackle #5 - I don't want a dangling feature for special encodings without the corresponding support for special characters. But the biggest ramification will be needing to mutate collections on the configuration, which currently only supports scalar values.