### PR TITLE
Use configurence

### DIFF
--- a/crystalfontz/config.py
+++ b/crystalfontz/config.py
@@ -2,261 +2,43 @@
 Configuration management for the Crystalfontz CLI.
 """
 
-from dataclasses import asdict, dataclass, field, fields, replace
-import logging
-import os
-import os.path
-from pathlib import Path
-from typing import Any, Callable, cast, Dict, NoReturn, Optional, Type
+from typing import cast, Optional
 
-try:
-    from typing import Self
-except ImportError:
-    Self = Any
-
-from appdirs import user_config_dir
-import yaml
+from configurence import BaseConfig, config, field, global_file
 
 from crystalfontz.baud import BaudRate, FAST_BAUD_RATE, SLOW_BAUD_RATE
 from crystalfontz.client import DEFAULT_RETRY_TIMES, DEFAULT_TIMEOUT
 
-try:
-    from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Dumper, Loader
-
-logger = logging.getLogger(__name__)
-
 APP_NAME = "crystalfontz"
-
-GLOBAL_FILE = f"/etc/{APP_NAME}.yaml"
-
-
-def default_file() -> str:
-    """
-    Get the default file path for the crystalfontz CLI.
-    """
-
-    return os.path.join(user_config_dir(APP_NAME), f"{APP_NAME}.yaml")
-
-
+GLOBAL_FILE = global_file(APP_NAME)
 DEFAULT_PORT = "/dev/ttyUSB0"
 
 
-def _metadata(env_var: Optional[str] = None) -> Dict[str, Any]:
-    return dict(env_var=env_var)
+def load_baud_rate(value: str) -> BaudRate:
+    rate: int = int(value)
+
+    if rate == SLOW_BAUD_RATE or rate == FAST_BAUD_RATE:
+        return cast(BaudRate, rate)
+    else:
+        raise ValueError(
+            f"{rate} is not a supported baud rate. "
+            f"Supported baud rates are {SLOW_BAUD_RATE} and {FAST_BAUD_RATE}"
+        )
 
 
-def _from_environment() -> Dict[str, Any]:
-    env: Dict[str, Any] = dict()
-    for f in fields(Config):
-        if f.metadata and "env_var" in f.metadata:
-            if f.metadata["env_var"] in os.environ:
-                var: Any = os.environ[f.metadata["env_var"]]
-                env[f.name] = cast(Any, f.type)(var)
-    return env
-
-
-@dataclass
-class Config:
+@config(APP_NAME)
+class Config(BaseConfig):
     """
     A configuration object. This class is typically used by the Crystalfontz CLI, but
     may also be useful for scripts or Jupyter notebooks using its configuration.
     """
 
-    port: str = field(
-        default=DEFAULT_PORT, metadata=_metadata(env_var="CRYSTALFONTZ_PORT")
-    )
-    model: str = field(default="CFA533", metadata=_metadata("CRYSTALFONTZ_MODEL"))
-    hardware_rev: Optional[str] = field(
-        default=None, metadata=_metadata(env_var="CRYSTALFONTZ_HARDWARE_REV")
-    )
-    firmware_rev: Optional[str] = field(
-        default=None, metadata=_metadata(env_var="CRYSTALFONTZ_FIRMWARE_REV")
-    )
+    port: str = field(default=DEFAULT_PORT, env_var="PORT")
+    model: str = field(default="CFA533", env_var="MODEL")
+    hardware_rev: Optional[str] = field(default=None, env_var="HARDWARE_REV")
+    firmware_rev: Optional[str] = field(default=None, env_var="FIRMWARE_REV")
     baud_rate: BaudRate = field(
-        default=SLOW_BAUD_RATE, metadata=_metadata(env_var="CRYSTALFONTZ_BAUD_RATE")
+        default=SLOW_BAUD_RATE, env_var="BAUD_RATE", load=load_baud_rate, dump=str
     )
-    timeout: float = field(
-        default=DEFAULT_TIMEOUT, metadata=_metadata(env_var="CRYSTALFONTZ_TIMEOUT")
-    )
-    retry_times: int = field(
-        default=DEFAULT_RETRY_TIMES,
-        metadata=_metadata(env_var="CRYSTALFONTZ_RETRY_TIMES"),
-    )
-    _file: Optional[str] = None
-
-    @property
-    def file(self: Self) -> str:
-        """
-        The configuration file path.
-        """
-        return self._file or default_file()
-
-    @classmethod
-    def from_environment(cls: Type[Self]) -> Self:
-        """
-        Load configuration from the environment.
-        """
-
-        logger.debug("Loading config from environment...")
-        return cls(**_from_environment())
-
-    @classmethod
-    def from_file(
-        cls: Type[Self],
-        file: Optional[str] = None,
-        load_environment: bool = False,
-        create_file: bool = False,
-    ) -> Self:
-        """
-        Load configuration from a file. Optionally load environment overrides and
-        optionally create the file.
-        """
-
-        _file: str = file or os.environ.get("CRYSTALFONTZ_CONFIG", default_file())
-
-        found_file = False
-        kwargs: Dict[str, Any] = dict(_file=_file)
-        try:
-            with open(_file, "r") as f:
-                found_file = True
-                logger.debug(f"Loading config from {_file}...")
-                kwargs.update(yaml.load(f, Loader=Loader))
-        except FileNotFoundError:
-            try:
-                with open(GLOBAL_FILE, "r") as f:
-                    logger.debug(f"Loading config from {GLOBAL_FILE}...")
-                    kwargs.update(yaml.load(f, Loader=Loader))
-            except FileNotFoundError:
-                pass
-
-        if load_environment:
-            logger.debug("Loading environment overrides...")
-            kwargs.update(_from_environment())
-
-        config = cls(**kwargs)
-
-        if not found_file and create_file:
-            config.to_file()
-
-        return config
-
-    def _assert_has(self: Self, name: str) -> None:
-        if not hasattr(self, name) or name.startswith("_"):
-            raise ValueError(f"Unknown configuration parameter {name}")
-
-    def get(self: Self, name: str) -> Any:
-        """
-        Get a configuration parameter by name.
-        """
-
-        self._assert_has(name)
-        return getattr(self, name)
-
-    def set(self: Self, name: str, value: str) -> None:
-        """
-        Set a configuration parameter by name and string value.
-        """
-
-        self._assert_has(name)
-
-        setters: Dict[Any, Callable[[str, str], None]] = {
-            str: self._set_str,
-            Optional[str]: self._set_str,
-            bool: self._set_bool,
-            BaudRate: self._set_baud_rate,
-            float: self._set_float,
-            Optional[float]: self._set_float,
-            int: self._set_int,
-            Optional[int]: self._set_int,
-        }
-        for f in fields(self):
-            if f.name == name:
-                if f.type in setters:
-                    setters[f.type](name, value)
-                    return
-                else:
-                    raise ValueError(f"Unknown type {f.type}")
-
-    def _set_str(self: Self, name: str, value: str) -> None:
-        setattr(self, name, value)
-
-    def _set_bool(self: Self, name: str, value: str) -> None:
-        if value.lower() in {"true", "yes", "y", "1"}:
-            setattr(self, name, True)
-        elif value.lower() in {"false", "no", "n", "0"}:
-            setattr(self, name, False)
-        else:
-            raise ValueError(f"Can not convert {value} to bool")
-
-    def _set_baud_rate(self: Self, name: str, value: str) -> None:
-        rate: int = int(value)
-        if rate == SLOW_BAUD_RATE or rate == FAST_BAUD_RATE:
-            setattr(self, name, rate)
-        else:
-            raise ValueError(
-                f"{rate} is not a supported baud rate. "
-                f"Supported baud rates are {SLOW_BAUD_RATE} and {FAST_BAUD_RATE}"
-            )
-
-    def _set_float(self: Self, name: str, value: str) -> None:
-        setattr(self, name, float(value))
-
-    def _set_int(self: Self, name: str, value: str) -> None:
-        setattr(self, name, int(value))
-
-    def unset(self: Self, name: str) -> None:
-        """
-        Unset an optional parameter.
-        """
-
-        self._assert_has(name)
-
-        unsetters: Dict[Any, Callable[[str], None]] = {
-            str: self._parameter_required,
-            Optional[str]: self._unset,
-            bool: self._parameter_required,
-            BaudRate: self._parameter_required,
-            float: self._parameter_required,
-            Optional[float]: self._unset,
-            int: self._parameter_required,
-            Optional[int]: self._unset,
-        }
-
-        for f in fields(self):
-            if f.name == name:
-                if f.type in unsetters:
-                    unsetters[f.type](name)
-                    return
-                else:
-                    raise ValueError(f"Unknown type {f.type}")
-
-    def _parameter_required(self: Self, name: str) -> NoReturn:
-        raise ValueError(f"{name} is a required configuraiton parameter")
-
-    def _unset(self: Self, name: str) -> None:
-        setattr(self, name, None)
-
-    def as_dict(self: Self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if not k.startswith("_")}
-
-    def to_file(self: Self, file: Optional[str] = None) -> Self:
-        """
-        Save the configuration to a file.
-        """
-
-        file = file or self.file
-
-        os.makedirs(Path(file).parent, exist_ok=True)
-
-        with open(file, "w") as f:
-            yaml.dump(self.as_dict(), f, Dumper=Dumper)
-
-        logger.info(f"Wrote configuration to {file}.")
-
-        return replace(self, _file=file)
-
-    def __repr__(self: Self) -> str:
-        return yaml.dump(self.as_dict(), Dumper=Dumper)
+    timeout: float = field(default=DEFAULT_TIMEOUT, env_var="TIMEOUT")
+    retry_times: int = field(default=DEFAULT_RETRY_TIMES, env_var="RETRY_TIMES")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,11 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "appdirs",
   "bitstring",
   "click",
+  "configurence",
   "pyserial",
   "pyserial-asyncio",
-  "pyyaml",
 ]
 
 [project.scripts]

--- a/tests/__snapshots__/test_config.ambr
+++ b/tests/__snapshots__/test_config.ambr
@@ -1,10 +1,12 @@
 # serializer version: 1
 # name: test_repr
   '''
-  baud_rate: 19200
+  baud_rate: '19200'
+  file: /etc/crystalfontz.yaml
   firmware_rev: null
   hardware_rev: null
   model: CFA533
+  name: crystalfontz
   port: /dev/ttyUSB0
   retry_times: 0
   timeout: 0.25

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,12 +3,12 @@ from typing import Any
 import pytest
 
 from crystalfontz.baud import FAST_BAUD_RATE
-from crystalfontz.config import Config
+from crystalfontz.config import Config, GLOBAL_FILE
 
 
 @pytest.fixture
 def config() -> Config:
-    return Config()
+    return Config(file=GLOBAL_FILE)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -209,16 +209,29 @@ wheels = [
 ]
 
 [[package]]
-name = "crystalfontz"
-version = "3.0.1"
-source = { editable = "." }
+name = "configurence"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
+    { name = "click" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/4c/99f5b39db827ef3bcbb77fe3fe636d6b9955d2997ef0986e835f0cd2229e/configurence-2.0.3.tar.gz", hash = "sha256:a40a8564bdeb2c905d7c1283b0974aae4c2378852033b66cbbae1facb0b4f065", size = 46872 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/b8/70aa8be08c721050f6e266c509064c67ded81a340b8d5e1c3082874b6315/configurence-2.0.3-py3-none-any.whl", hash = "sha256:df4d8f14f523c4e67bb8c77a08dcf43f9787c8f8a193715613515b32af795605", size = 5056 },
+]
+
+[[package]]
+name = "crystalfontz"
+version = "4.0.0"
+source = { editable = "." }
+dependencies = [
     { name = "bitstring" },
     { name = "click" },
+    { name = "configurence" },
     { name = "pyserial" },
     { name = "pyserial-asyncio" },
-    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -239,12 +252,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "appdirs" },
     { name = "bitstring" },
     { name = "click" },
+    { name = "configurence" },
     { name = "pyserial" },
     { name = "pyserial-asyncio" },
-    { name = "pyyaml" },
 ]
 
 [package.metadata.requires-dev]
@@ -265,23 +277,23 @@ dev = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.11"
+version = "1.8.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/e7/666f4c9b0e24796af50aadc28d36d21c2e01e831a934535f956e09b3650c/debugpy-1.8.11.tar.gz", hash = "sha256:6ad2688b69235c43b020e04fecccdf6a96c8943ca9c2fb340b8adc103c655e57", size = 1640124 }
+sdist = { url = "https://files.pythonhosted.org/packages/68/25/c74e337134edf55c4dfc9af579eccb45af2393c40960e2795a94351e8140/debugpy-1.8.12.tar.gz", hash = "sha256:646530b04f45c830ceae8e491ca1c9320a2d2f0efea3141487c82130aba70dce", size = 1641122 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/58/8e3f7ec86c1b7985a232667b5df8f3b1b1c8401028d8f4d75e025c9556cd/debugpy-1.8.11-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:85de8474ad53ad546ff1c7c7c89230db215b9b8a02754d41cb5a76f70d0be296", size = 2173656 },
-    { url = "https://files.pythonhosted.org/packages/d2/03/95738a68ade2358e5a4d63a2fd8e7ed9ad911001cfabbbb33a7f81343945/debugpy-1.8.11-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ffc382e4afa4aee367bf413f55ed17bd91b191dcaf979890af239dda435f2a1", size = 3132464 },
-    { url = "https://files.pythonhosted.org/packages/ca/f4/18204891ab67300950615a6ad09b9de236203a9138f52b3b596fa17628ca/debugpy-1.8.11-cp311-cp311-win32.whl", hash = "sha256:40499a9979c55f72f4eb2fc38695419546b62594f8af194b879d2a18439c97a9", size = 5103637 },
-    { url = "https://files.pythonhosted.org/packages/3b/90/3775e301cfa573b51eb8a108285681f43f5441dc4c3916feed9f386ef861/debugpy-1.8.11-cp311-cp311-win_amd64.whl", hash = "sha256:987bce16e86efa86f747d5151c54e91b3c1e36acc03ce1ddb50f9d09d16ded0e", size = 5127862 },
-    { url = "https://files.pythonhosted.org/packages/c6/ae/2cf26f3111e9d94384d9c01e9d6170188b0aeda15b60a4ac6457f7c8a26f/debugpy-1.8.11-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:84e511a7545d11683d32cdb8f809ef63fc17ea2a00455cc62d0a4dbb4ed1c308", size = 2498756 },
-    { url = "https://files.pythonhosted.org/packages/b0/16/ec551789d547541a46831a19aa15c147741133da188e7e6acf77510545a7/debugpy-1.8.11-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce291a5aca4985d82875d6779f61375e959208cdf09fcec40001e65fb0a54768", size = 4219136 },
-    { url = "https://files.pythonhosted.org/packages/72/6f/b2b3ce673c55f882d27a6eb04a5f0c68bcad6b742ac08a86d8392ae58030/debugpy-1.8.11-cp312-cp312-win32.whl", hash = "sha256:28e45b3f827d3bf2592f3cf7ae63282e859f3259db44ed2b129093ca0ac7940b", size = 5224440 },
-    { url = "https://files.pythonhosted.org/packages/77/09/b1f05be802c1caef5b3efc042fc6a7cadd13d8118b072afd04a9b9e91e06/debugpy-1.8.11-cp312-cp312-win_amd64.whl", hash = "sha256:44b1b8e6253bceada11f714acf4309ffb98bfa9ac55e4fce14f9e5d4484287a1", size = 5264578 },
-    { url = "https://files.pythonhosted.org/packages/2e/66/931dc2479aa8fbf362dc6dcee707d895a84b0b2d7b64020135f20b8db1ed/debugpy-1.8.11-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:8988f7163e4381b0da7696f37eec7aca19deb02e500245df68a7159739bbd0d3", size = 2483651 },
-    { url = "https://files.pythonhosted.org/packages/10/07/6c171d0fe6b8d237e35598b742f20ba062511b3a4631938cc78eefbbf847/debugpy-1.8.11-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c1f6a173d1140e557347419767d2b14ac1c9cd847e0b4c5444c7f3144697e4e", size = 4213770 },
-    { url = "https://files.pythonhosted.org/packages/89/f1/0711da6ac250d4fe3bf7b3e9b14b4a86e82a98b7825075c07e19bab8da3d/debugpy-1.8.11-cp313-cp313-win32.whl", hash = "sha256:bb3b15e25891f38da3ca0740271e63ab9db61f41d4d8541745cfc1824252cb28", size = 5223911 },
-    { url = "https://files.pythonhosted.org/packages/56/98/5e27fa39050749ed460025bcd0034a0a5e78a580a14079b164cc3abdeb98/debugpy-1.8.11-cp313-cp313-win_amd64.whl", hash = "sha256:d8768edcbeb34da9e11bcb8b5c2e0958d25218df7a6e56adf415ef262cd7b6d1", size = 5264166 },
-    { url = "https://files.pythonhosted.org/packages/77/0a/d29a5aacf47b4383ed569b8478c02d59ee3a01ad91224d2cff8562410e43/debugpy-1.8.11-py2.py3-none-any.whl", hash = "sha256:0e22f846f4211383e6a416d04b4c13ed174d24cc5d43f5fd52e7821d0ebc8920", size = 5226874 },
+    { url = "https://files.pythonhosted.org/packages/af/9f/5b8af282253615296264d4ef62d14a8686f0dcdebb31a669374e22fff0a4/debugpy-1.8.12-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:36f4829839ef0afdfdd208bb54f4c3d0eea86106d719811681a8627ae2e53dd5", size = 2174643 },
+    { url = "https://files.pythonhosted.org/packages/ef/31/f9274dcd3b0f9f7d1e60373c3fa4696a585c55acb30729d313bb9d3bcbd1/debugpy-1.8.12-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a28ed481d530e3138553be60991d2d61103ce6da254e51547b79549675f539b7", size = 3133457 },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/6ee59e9892e424477e0c76e3798046f1fd1288040b927319c7a7b0baa484/debugpy-1.8.12-cp311-cp311-win32.whl", hash = "sha256:4ad9a94d8f5c9b954e0e3b137cc64ef3f579d0df3c3698fe9c3734ee397e4abb", size = 5106220 },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/8ab508ab05ede8a4eae3b139bbc06ea3ca6234f9e8c02713a044f253be5e/debugpy-1.8.12-cp311-cp311-win_amd64.whl", hash = "sha256:4703575b78dd697b294f8c65588dc86874ed787b7348c65da70cfc885efdf1e1", size = 5130481 },
+    { url = "https://files.pythonhosted.org/packages/ba/e6/0f876ecfe5831ebe4762b19214364753c8bc2b357d28c5d739a1e88325c7/debugpy-1.8.12-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:7e94b643b19e8feb5215fa508aee531387494bf668b2eca27fa769ea11d9f498", size = 2500846 },
+    { url = "https://files.pythonhosted.org/packages/19/64/33f41653a701f3cd2cbff8b41ebaad59885b3428b5afd0d93d16012ecf17/debugpy-1.8.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:086b32e233e89a2740c1615c2f775c34ae951508b28b308681dbbb87bba97d06", size = 4222181 },
+    { url = "https://files.pythonhosted.org/packages/32/a6/02646cfe50bfacc9b71321c47dc19a46e35f4e0aceea227b6d205e900e34/debugpy-1.8.12-cp312-cp312-win32.whl", hash = "sha256:2ae5df899732a6051b49ea2632a9ea67f929604fd2b036613a9f12bc3163b92d", size = 5227017 },
+    { url = "https://files.pythonhosted.org/packages/da/a6/10056431b5c47103474312cf4a2ec1001f73e0b63b1216706d5fef2531eb/debugpy-1.8.12-cp312-cp312-win_amd64.whl", hash = "sha256:39dfbb6fa09f12fae32639e3286112fc35ae976114f1f3d37375f3130a820969", size = 5267555 },
+    { url = "https://files.pythonhosted.org/packages/cf/4d/7c3896619a8791effd5d8c31f0834471fc8f8fb3047ec4f5fc69dd1393dd/debugpy-1.8.12-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:696d8ae4dff4cbd06bf6b10d671e088b66669f110c7c4e18a44c43cf75ce966f", size = 2485246 },
+    { url = "https://files.pythonhosted.org/packages/99/46/bc6dcfd7eb8cc969a5716d858e32485eb40c72c6a8dc88d1e3a4d5e95813/debugpy-1.8.12-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:898fba72b81a654e74412a67c7e0a81e89723cfe2a3ea6fcd3feaa3395138ca9", size = 4218616 },
+    { url = "https://files.pythonhosted.org/packages/03/dd/d7fcdf0381a9b8094da1f6a1c9f19fed493a4f8576a2682349b3a8b20ec7/debugpy-1.8.12-cp313-cp313-win32.whl", hash = "sha256:22a11c493c70413a01ed03f01c3c3a2fc4478fc6ee186e340487b2edcd6f4180", size = 5226540 },
+    { url = "https://files.pythonhosted.org/packages/25/bd/ecb98f5b5fc7ea0bfbb3c355bc1dd57c198a28780beadd1e19915bf7b4d9/debugpy-1.8.12-cp313-cp313-win_amd64.whl", hash = "sha256:fdb3c6d342825ea10b90e43d7f20f01535a72b3a1997850c0c3cefa5c27a4a2c", size = 5267134 },
+    { url = "https://files.pythonhosted.org/packages/38/c4/5120ad36405c3008f451f94b8f92ef1805b1e516f6ff870f331ccb3c4cc0/debugpy-1.8.12-py2.py3-none-any.whl", hash = "sha256:274b6a2040349b5c9864e475284bce5bb062e63dce368a394b8cc865ae3b00c6", size = 5229490 },
 ]
 
 [[package]]
@@ -295,11 +307,11 @@ wheels = [
 
 [[package]]
 name = "executing"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab", size = 977485 }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf", size = 25805 },
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
 ]
 
 [[package]]
@@ -352,14 +364,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.5.4"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/9b/0bc9d53ed6628aae43223dd3c081637da54f66ed17a8c1d9fd36ee5da244/griffe-1.5.4.tar.gz", hash = "sha256:073e78ad3e10c8378c2f798bd4ef87b92d8411e9916e157fd366a17cc4fd4e52", size = 389376 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/74/cd35a98cb11f79de0581e8e1e6fbd738aeeed1f2d90e9b5106728b63f5f7/griffe-1.5.5.tar.gz", hash = "sha256:35ee5b38b93d6a839098aad0f92207e6ad6b70c3e8866c08ca669275b8cba585", size = 391124 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/29/d0f156c076ec71eb485e70cbcde4872e3c045cda965a48d1d938aa3d9f76/griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d", size = 128102 },
+    { url = "https://files.pythonhosted.org/packages/1f/88/52c9422bc853cd7c2b6122090e887d17b5fad29b67f930e4277c9c557357/griffe-1.5.5-py3-none-any.whl", hash = "sha256:2761b1e8876c6f1f9ab1af274df93ea6bbadd65090de5f38f4cb5cc84897c7dd", size = 128221 },
 ]
 
 [[package]]
@@ -611,16 +623,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/ae/0f1154c614d6a8b8a36fff084e5b82af3a15f7d2060cf0dcdb1c53297a71/mkdocs_autorefs-1.2.0.tar.gz", hash = "sha256:a86b93abff653521bda71cf3fc5596342b7a23982093915cb74273f67522190f", size = 40262 }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/18/fb1e17fb705228b51bf7b2f791adaf83c0fa708e51bbc003411ba48ae21e/mkdocs_autorefs-1.3.0.tar.gz", hash = "sha256:6867764c099ace9025d6ac24fd07b85a98335fbd30107ef01053697c8f46db61", size = 42597 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/26/4d39d52ea2219604053a4d05b98e90d6a335511cc01806436ec4886b1028/mkdocs_autorefs-1.2.0-py3-none-any.whl", hash = "sha256:d588754ae89bd0ced0c70c06f58566a4ee43471eeeee5202427da7de9ef85a2f", size = 16522 },
+    { url = "https://files.pythonhosted.org/packages/f4/4a/960c441950f98becfa5dd419adab20274939fd575ab848aee2c87e3599ac/mkdocs_autorefs-1.3.0-py3-none-any.whl", hash = "sha256:d180f9778a04e78b7134e31418f238bba56f56d6a8af97873946ff661befffb3", size = 17642 },
 ]
 
 [[package]]
@@ -765,14 +777,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.48"
+version = "3.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
 ]
 
 [[package]]
@@ -837,24 +849,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.18.0"
+version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.13"
+version = "10.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/87/4998d1aac5afea5b081238a609d9814f4c33cd5c7123503276d1105fb6a9/pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd", size = 843302 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/24/f7a412dc1630b1a6d7b288e7c736215ce878ee4aad24359f7f67b53bbaa9/pymdown_extensions-10.14.1.tar.gz", hash = "sha256:b65801996a0cd4f42a3110810c306c45b7313c09b0610a6f773730f2a9e3c96b", size = 845243 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/7f/46c7122186759350cf523c71d29712be534f769f073a1d980ce8f095072c/pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428", size = 264108 },
+    { url = "https://files.pythonhosted.org/packages/09/fb/79a8d27966e90feeeb686395c8b1bff8221727abcbd80d2485841393a955/pymdown_extensions-10.14.1-py3-none-any.whl", hash = "sha256:637951cbfbe9874ba28134fb3ce4b8bcadd6aca89ac4998ec29dcbafd554ae08", size = 264283 },
 ]
 
 [[package]]
@@ -895,14 +907,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.1"
+version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/04/0477a4bdd176ad678d148c075f43620b3f7a060ff61c7da48500b1fa8a75/pytest_asyncio-0.25.1.tar.gz", hash = "sha256:79be8a72384b0c917677e00daa711e07db15259f4d23203c59012bcd989d4aee", size = 53760 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/fb/efc7226b384befd98d0e00d8c4390ad57f33c8fde00094b85c5e07897def/pytest_asyncio-0.25.1-py3-none-any.whl", hash = "sha256:c84878849ec63ff2ca509423616e071ef9cd8cc93c053aa33b5b8fb70a990671", size = 19357 },
+    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400 },
 ]
 
 [[package]]
@@ -1061,14 +1073,14 @@ wheels = [
 
 [[package]]
 name = "syrupy"
-version = "4.8.0"
+version = "4.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/54/07f40c1e9355c0eb6909b83abd8ea2c523a1e05b8257a575bbaa42df28de/syrupy-4.8.0.tar.gz", hash = "sha256:648f0e9303aaa8387c8365d7314784c09a6bab0a407455c6a01d6a4f5c6a8ede", size = 49526 }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/32/8b56491ed50ae103c2db14885c29fe765170bdf044fe5868548113da35ef/syrupy-4.8.1.tar.gz", hash = "sha256:8da8c0311e6d92de0b15767768c6ab98982b7b4a4c67083c08fbac3fbad4d44c", size = 50192 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl", hash = "sha256:544f4ec6306f4b1c460fdab48fd60b2c7fe54a6c0a8243aeea15f9ad9c638c3f", size = 49530 },
+    { url = "https://files.pythonhosted.org/packages/80/47/5e8f44ec0f287b08e8c1f3fc63fe1fbe182f07bf606eec903d7827b95e51/syrupy-4.8.1-py3-none-any.whl", hash = "sha256:274f97cbaf44175f5e478a2f3a53559d31f41c66c6bf28131695f94ac893ea00", size = 50326 },
 ]
 
 [[package]]
@@ -1100,11 +1112,11 @@ wheels = [
 
 [[package]]
 name = "trove-classifiers"
-version = "2024.10.21.16"
+version = "2025.1.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/85/92c2667cf221b37648041ce9319427f92fa76cbec634aad844e67e284706/trove_classifiers-2024.10.21.16.tar.gz", hash = "sha256:17cbd055d67d5e9d9de63293a8732943fabc21574e4c7b74edf112b4928cf5f3", size = 16153 }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/cb/8f6a91c74049180e395590901834d68bef5d6a2ce4c9ca9792cfadc1b9b4/trove_classifiers-2025.1.15.22.tar.gz", hash = "sha256:90af74358d3a01b3532bc7b3c88d8c6a094c2fd50a563d13d9576179326d7ed9", size = 16236 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/35/5055ab8d215af853d07bbff1a74edf48f91ed308f037380a5ca52dd73348/trove_classifiers-2024.10.21.16-py3-none-any.whl", hash = "sha256:0fb11f1e995a757807a8ef1c03829fbd4998d817319abcef1f33165750f103be", size = 13546 },
+    { url = "https://files.pythonhosted.org/packages/2b/c5/6422dbc59954389b20b2aba85b737ab4a552e357e7ea14b52f40312e7c84/trove_classifiers-2025.1.15.22-py3-none-any.whl", hash = "sha256:5f19c789d4f17f501d36c94dbbf969fb3e8c2784d008e6f5164dd2c3d6a2b07c", size = 13610 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates `crystalfontz` to use the `configurence` library for its config.

It appears to be working. I'm gonna go ahead and merge based on unit tests and a `crystalfontz config show`, and plan on running full integration tests prior to the next release.