### PR TITLE
Refactor Response constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Improved error handling
   - Introduce `Receiver` type, a subclass of `asyncio.Queue`
   - Emit unmatched exceptions on expecting receivers instead of resolving `client.closed`
+- `Response` class API changes
+  - `Response.from_bytes` accepts bytes as from packets, rather than `__init__`
+  - `Response.__init__` accepts properties as arguments
 
 ## 2025/01/12 Version 4.0.0
 - Fedora package on COPR: <https://copr.fedorainfracloud.org/coprs/jfhbrook/joshiverse/package/python-crystalfontz/>

--- a/crystalfontz/response.py
+++ b/crystalfontz/response.py
@@ -120,8 +120,8 @@ class Versions(Response):
 
     def __init__(self: Self, model: str, hardware_rev: str, firmware_rev: str) -> None:
         self.model: str = model
-        self.hardware_rev: str = hardware_rev.strip()
-        self.firmware_rev: str = firmware_rev.strip()
+        self.hardware_rev: str = hardware_rev
+        self.firmware_rev: str = firmware_rev
 
     @classmethod
     def from_bytes(cls: Type[Self], data: bytes) -> Self:
@@ -129,7 +129,7 @@ class Versions(Response):
         model, versions = decoded.split(":")
         hw_rev, fw_rev = versions.split(",")
 
-        return cls(model, hw_rev, fw_rev)
+        return cls(model, hw_rev.strip(), fw_rev.strip())
 
     def __str__(self: Self) -> str:
         return (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,11 +37,11 @@ def test_parse_bytes(text, buffer) -> None:
 
 
 OBJECTS = [
-    Versions(b"CFA533: h1.4, u1v2"),
-    LcdMemory(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
-    DowDeviceInformation(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
-    DowTransactionResult(b"\xff\x01\x02\x03\x04\x05\x06\x07\xff"),
-    KeypadPolled(bytes([KP_UP, KP_UP, KP_UP])),
+    Versions.from_bytes(b"CFA533: h1.4, u1v2"),
+    LcdMemory.from_bytes(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
+    DowDeviceInformation.from_bytes(b"\xff\x00\x01\x02\x03\x04\x05\x06\x07"),
+    DowTransactionResult.from_bytes(b"\xff\x01\x02\x03\x04\x05\x06\x07\xff"),
+    KeypadPolled.from_bytes(bytes([KP_UP, KP_UP, KP_UP])),
     CFA533Status(
         temperature_sensors_enabled={1, 2},
         key_states=KeyStates(
@@ -66,7 +66,7 @@ OBJECTS = [
         cfa633_contrast=0.5,
         lcd_brightness=0.5,
     ),
-    GpioRead(bytes([0xFF, 0b0111, 0x11, 0b1101])),
+    GpioRead.from_bytes(bytes([0xFF, 0b0111, 0x11, 0b1101])),
     b"\01",
 ]
 


### PR DESCRIPTION
I refactored the `Response` classes to accept the underlying properties as arguments in `__init__`, and handle constructing from bytes in a `from_bytes` class method.

I think this change is safe. But we'll need to test it out before release.

Closes #54